### PR TITLE
Add support for older ruby versions

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -1,3 +1,4 @@
+require "backports" if RUBY_VERSION < "1.9"
 require "pundit/version"
 require "pundit/policy_finder"
 require "active_support/concern"

--- a/pundit.gemspec
+++ b/pundit.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "rails", "~>3.0"
+  gem.add_dependency "backports", "~>2.0" if RUBY_VERSION < "1.9"
+
   gem.add_development_dependency "rspec", "~>2.0"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
#3 I know it's time, but some legacy projects just need some love.

If somehow it's  acceptable for you to add an "unoffical" support for ruby 1.8.7, theres a gem that adds the function and methods like public_send.
