### PR TITLE
Allows Scope to receive additional arguments

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -50,11 +50,11 @@ module Pundit
     true
   end
 
-  def policy_scope(scope)
-    Pundit.policy_scope!(current_user, scope)
+  def policy_scope(scope, *args)
+    Pundit.policy_scope!(current_user, scope, *args)
   end
 
-  def policy(record)
-    Pundit.policy!(current_user, record)
+  def policy(record, *args)
+    Pundit.policy!(current_user, record, *args)
   end
 end

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -76,6 +76,7 @@ describe Pundit do
   let(:controller) { stub(:current_user => user, :params => { :action => "update" }).tap { |c| c.extend(Pundit) } }
   let(:artificial_blog) { ArtificialBlog.new }
   let(:article_tag) { ArticleTag.new }
+  let(:blog_contributor) { BlogContributor.new }
 
   describe ".policy_scope" do
     it "returns an instantiated policy scope given a plain model class" do
@@ -209,7 +210,7 @@ describe Pundit do
     end
 
     it "returns an instantiated policy given a plain model class when extra arguments are passed" do
-      policy = Pundit.policy!(user, BlogContributor, :true)
+      policy = Pundit.policy!(user, BlogContributor, true)
       policy.user.should == user
       policy.contributor.should == BlogContributor
       policy.restrict.should be_true
@@ -262,11 +263,22 @@ describe Pundit do
     it "throws an exception if the given policy can't be found" do
       expect { controller.policy(article) }.to raise_error(Pundit::NotDefinedError)
     end
+
+    it "returns an instantiated policy when extra arguments are passed" do
+      policy = controller.policy(blog_contributor, true)
+      policy.user.should == user
+      policy.contributor.should == blog_contributor
+      policy.restrict.should be_true
+    end
   end
 
   describe ".policy_scope" do
     it "returns an instantiated policy scope" do
       controller.policy_scope(Post).should == :published
+    end
+
+    it "returns an instantiated policy scope when extra arguments are passed" do
+      controller.policy_scope(Blog, true).should == :active
     end
 
     it "throws an exception if the given policy can't be found" do


### PR DESCRIPTION
For times when scope resolution depends on data not related to the current user or the model/class, it may be useful to allow the Scope to accept more than just these two arguments.

As an example, I recently had to do something like this in a Rails action, basing the resolved scope in part on the request `params`.

``` ruby
render json: policy_scope(user.articles, (params.include?(:historical)) && ::User::UserPolicy.new(current_user, user).manage?)
```
