### PR TITLE
Change default index? policy to false

### DIFF
--- a/lib/generators/pundit/install/templates/application_policy.rb
+++ b/lib/generators/pundit/install/templates/application_policy.rb
@@ -7,7 +7,7 @@ class ApplicationPolicy
   end
 
   def index?
-    scope.exists?
+    false
   end
 
   def show?


### PR DESCRIPTION
See gh-17 for initial discussion.  I think that the default provided
before this commit is confusing, because an empty result is not a
good indicator of authorization failure.  Returning false better
communicates "override this is you want it".
