### PR TITLE
Make pundit methods non-public

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -34,11 +34,8 @@ module Pundit
     if respond_to?(:helper_method)
       helper_method :policy_scope
       helper_method :policy
-
-      protected :policy_scope
-      protected :policy
-      protected :verify_authorized
-      protected :authorize
+      helper_method :verify_authorized
+      helper_method :authorize
     end
   end
 


### PR DESCRIPTION
Pundit methods should not be public as public methods show up as controller actions, which they are not.
