### PR TITLE
Additional flexibility on authorize to allow optional parameters

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -45,10 +45,10 @@ module Pundit
     raise NotAuthorizedError unless @_policy_authorized
   end
 
-  def authorize(record, query=nil)
+  def authorize(record, query=nil, arguments=[])
     query ||= params[:action].to_s + "?"
     @_policy_authorized = true
-    unless policy(record).public_send(query)
+    unless policy(record).public_send(query, *arguments)
       raise NotAuthorizedError, "not allowed to #{query} this #{record}"
     end
     true


### PR DESCRIPTION
Added the ability to pass parameters to the authorizing method. The modification is on authorize. It adds an additional parameter arguments initialized to an empty list. public_send accepts this as a list to bind arguments to if using *arguments as the second parameter. Thus, it does not break any current functionality, but extends the functionality of pundit to methods which require additional inputs
