### PR TITLE
Add #verify_policy_scoped for controller usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,18 @@ class ApplicationController < ActionController::Base
 end
 ```
 
+Likewise, pundit also adds `verify_policy_scoped` to your controller.  This
+will raise an exception in the vein of `verify_authorized`.  However it tracks
+if `policy_scoped` is used instead of `authorize`.  This is mostly useful for
+controller actions like `index` which find collections with a scope and don't
+authorize individual instances.
+
+``` ruby
+class ApplicationController < ActionController::Base
+  after_filter :verify_policy_scoped, :only => :index
+end
+```
+
 ## Scopes
 
 Often, you will want to have some kind of view listing records which a

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -38,11 +38,16 @@ module Pundit
     if respond_to?(:hide_action)
       hide_action :authorize
       hide_action :verify_authorized
+      hide_action :verify_policy_scoped
     end
   end
 
   def verify_authorized
     raise NotAuthorizedError unless @_policy_authorized
+  end
+
+  def verify_policy_scoped
+    raise NotAuthorizedError unless @_policy_scoped
   end
 
   def authorize(record, query=nil)
@@ -55,6 +60,7 @@ module Pundit
   end
 
   def policy_scope(scope)
+    @_policy_scoped = true
     Pundit.policy_scope!(current_user, scope)
   end
 

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -194,6 +194,17 @@ describe Pundit do
     end
   end
 
+  describe "#verify_policy_scoped" do
+    it "does nothing when policy_scope is used" do
+      controller.policy_scope(Post)
+      controller.verify_policy_scoped
+    end
+
+    it "raises an exception when policy_scope is not used" do
+      expect { controller.verify_policy_scoped }.to raise_error(Pundit::NotAuthorizedError)
+    end
+  end
+
   describe "#authorize" do
     it "infers the policy name and authorized based on it" do
       controller.authorize(post).should be_true


### PR DESCRIPTION
See the readme changes for an example.  In short, this behaves
like verify_authorized but is useful for actions that find a
collection (like index) and don't authorize instances.
