### PR TITLE
[Feature] Custom error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,17 @@ allows you to customize the error messages if authorization fails.
 authorize @post, :destroy?, "sorry, we support freedom of speech"
 ```
 
+You can also provide a custom error message from within a policy, just declare a
+method called `error_message` that accepts a `query parameter and you're good to go.
+
+``` ruby
+class MessagePolicy < ApplicationPolicy
+  def error_message(query)
+    @error_message ||= "whoa there, I don't think you're allowed to #{query} this #{record}"
+  end
+end
+```
+
 ## RSpec
 
 Pundit includes a mini-DSL for writing expressive tests for your policies in RSpec.

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -46,10 +46,11 @@ module Pundit
   end
 
   def authorize(record, query = nil, message = nil)
+    policy = policy(record)
     query   ||= params[:action].to_s + "?"
-    message ||= "not allowed to #{query} this #{record}"
+    message ||= policy.respond_to?(:error_message) ? policy.error_message(query) : "not allowed to #{query} this #{record}"
     @_policy_authorized = true
-    unless policy(record).public_send(query)
+    unless policy.public_send(query)
       raise NotAuthorizedError, message
     end
     true

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -54,11 +54,20 @@ class ArticleTag
   end
 end
 
+class MessagePolicy < Struct.new(:user, :message)
+  def destroy?; false; end
+  def error_message(scope)
+    @error_message ||= "error message set from within the policy"
+  end
+end
+class Message; end
+
 describe Pundit do
   let(:user) { stub }
   let(:post) { Post.new(user) }
   let(:comment) { Comment.new }
   let(:article) { Article.new }
+  let(:message) { Message.new }
   let(:controller) { stub(:current_user => user, :params => { :action => "update" }).tap { |c| c.extend(Pundit) } }
   let(:artificial_blog) { ArtificialBlog.new }
   let(:article_tag) { ArticleTag.new }
@@ -216,6 +225,10 @@ describe Pundit do
     it "raises an error with a custom error message" do
       custom_message = "custom error message"
       expect { controller.authorize(post, :destroy?, custom_message) }.to raise_error(Pundit::NotAuthorizedError,custom_message)
+    end
+
+    it "raises an error with a custom error message defined in the policy" do
+      expect { controller.authorize(message, :destroy?) }.to raise_error(Pundit::NotAuthorizedError,MessagePolicy.new.error_message('destroy'))
     end
 
   end


### PR DESCRIPTION
From updated **README.md**:
## Custom error messages

In rails you probably want to use `rescue_from Pundit::NotAuthorizedError` in your
controllers and display some nice error page or an informative API response. Pundit
allows you to customize the error messages if authorization fails.

``` ruby
authorize @post, :destroy?, "sorry, we support freedom of speech"
```

You can also provide a custom error message from within a policy, just declare a
method called `error_message` that accepts a `query` parameter and you're good to go.

``` ruby
class MessagePolicy < ApplicationPolicy
  def error_message(query)
    @error_message ||= "whoa there, I don't think you're allowed to #{query} this #{record}"
  end
end
```
