### PR TITLE
[Feature] Policy Serializer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,49 @@ class ApplicationPolicy
 end
 ```
 
+## Serialized Policies
+
+In some applications you might want to provide a client API. Pundit helps
+provide your authorization policies as first class citizens, by giving you
+a way to convert a policy to a hash. It's easy, just include the serializer
+module and you're good to go.
+
+```ruby
+class MessagePolicy
+
+  include Pundit::Serializer
+
+  attr_reader :user, :message
+
+  def initialize(user, message)
+    @user = user
+    @message = message
+  end
+
+  def create?
+    not message.new_record?
+  end
+
+  def destroy?
+    message.user == user
+  end
+
+end
+```
+
+Now you can call `#to_h` on the policy with the module included.
+
+```ruby
+@message_policy = MessagePolicy.new(current_user,@message)
+@message_policy.to_h
+# => { create: true, destroy: true }
+```
+
+**Note:** For the serializer to work, you need to use the pundit naming
+convention for queries with the interrogation point in the end `index?`.
+
+The serializer also works for inherited policies.
+
 ## Manually retrieving policies and scopes
 
 Sometimes you want to retrieve a policy for a record outside the controller or

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -1,5 +1,6 @@
 require "pundit/version"
 require "pundit/policy_finder"
+require "pundit/serializer"
 require "active_support/concern"
 require "active_support/core_ext/string/inflections"
 require "active_support/core_ext/object/blank"

--- a/lib/pundit/serializer.rb
+++ b/lib/pundit/serializer.rb
@@ -1,0 +1,21 @@
+module Pundit
+  module Serializer
+
+    def to_h
+      hash = Hash.new
+      serialize_queries.each do |query|
+        if self.respond_to?(query)
+          hash[query.to_s.gsub('?','').to_sym] = self.public_send(query)
+        end
+      end
+      hash
+    end
+
+    def serialize_queries
+      @serialize_queries ||= self.public_methods.delete_if do |pm|
+        not self.method(pm).owner.to_s.match(/.*Policy$/) or not pm.to_s.match(/.*\?$/)
+      end.sort
+    end
+
+  end
+end


### PR DESCRIPTION
Taken from the updated **README.md**:
## Serialized Policies

In some applications you might want to provide a client API. Pundit helps
provide your authorization policies as first class citizens, by giving you
a way to convert a policy to a hash. It's easy, just include the serializer
module and you're good to go.

``` ruby
class MessagePolicy

  include Pundit::Serializer

  attr_reader :user, :message

  def initialize(user, message)
    @user = user
    @message = message
  end

  def create?
    not message.new_record?
  end

  def destroy?
    message.user == user
  end

end
```

Now you can call `#to_h` on the policy with the module included.

``` ruby
@message_policy = MessagePolicy.new(current_user,@message)
@message_policy.to_h
# => { create: true, destroy: true }
```

**Note:** For the serializer to work, you need to use the pundit naming
convention for queries with the interrogation point in the end `index?`

The serializer also works for inherited policies.
