### PR TITLE
Allow custom error messages to be passed to authorize call

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,10 +283,78 @@ Pundit.policy_scope(user, Post)
 The bang methods will raise an exception if the policy does not exist, whereas
 those without the bang will return nil.
 
+## Error messages
+
+Pundit raises a `Pundit::NotAuthorizedError` you can [rescue_from](http://guides.rubyonrails.org/action_controller_overview.html#rescue_from) in your `ApplicationController`. You can customize the `user_not_authorized` method in every controller based on your needs.
+
+```ruby
+class ApplicationController < ActionController::Base
+  protect_from_forgery
+  include Pundit
+
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+  private
+
+  def user_not_authorized
+    flash[:error] = "You are not authorized to perform this action."
+    redirect_to :back
+  end
+end
+```
+
+You can customize the exception message.
+
+``` ruby
+class PostsController < ApplicationController
+  def create
+    @post = Post.new(params[:post])
+
+    # Note that the error_message is the third argument
+    # Pass in nil as the second argument to let pundit
+    # determine the action automatically
+    authorize @post, :create?, "You cannot create new posts."
+
+    if @post.save
+      redirect_to @post
+    else
+      render :new
+    end
+  end
+end
+```
+
+```ruby
+class ApplicationController < ActionController::Base
+  protect_from_forgery
+  include Pundit
+
+  rescue_from Pundit::NotAuthorizedError do |exception|
+    user_not_authorized(exception)
+  end
+
+  private
+
+  def user_not_authorized(exception)
+    flash[:error] = authorization_error_message(exception.message)
+    redirect_to :back
+  end
+
+  def authorization_error_message(message)
+    case message
+    when 'Pundit::NotAuthorizedError'
+      "You are not authorized to perform this action."
+    else
+      message
+    end
+  end
+end
+```
+
 ## Pundit and strong_parameters
 
 In Rails 3 using [strong_parameters](https://github.com/rails/strong_parameters)
-or a standard Rails 4 setup, mass-assignment protection is handled in the controller. 
+or a standard Rails 4 setup, mass-assignment protection is handled in the controller.
 Pundit helps you permit different attributes for different users.
 
 ```ruby

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -50,11 +50,12 @@ module Pundit
     raise NotAuthorizedError unless @_policy_scoped
   end
 
-  def authorize(record, query=nil)
+  def authorize(record, query=nil, error_message=nil)
     query ||= params[:action].to_s + "?"
+    error_message ||= "not allowed to #{query} this #{record}"
     @_policy_authorized = true
     unless policy(record).public_send(query)
-      raise NotAuthorizedError, "not allowed to #{query} this #{record}"
+      raise NotAuthorizedError, error_message
     end
     true
   end

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -224,6 +224,10 @@ describe Pundit do
     it "raises an error when the permission check fails" do
       expect { controller.authorize(Post.new) }.to raise_error(Pundit::NotAuthorizedError)
     end
+
+    it "can be given a custom error message" do
+      expect { controller.authorize(Post.new, nil,'not authorized') }.to raise_error(Pundit::NotAuthorizedError, 'not authorized')
+    end
   end
 
   describe ".policy" do


### PR DESCRIPTION
- Add Readme section on rescuing from `Pundit::NotAuthorizedError` in Rails.
- Allow custom error messages to be set in controller actions.

Regarding the custom error messages, I think that passing in a custom error message in the controller action should suffice.

``` ruby
authorize @post, :create?, "You cannot create new posts."
```

 #20 and #32 proposed custom `error_message(query)` methods on the policy, but I'm unsure whether this will bring us any further. Would you check the implementation and docs section @jnicklas and add in any other ways you might be rescuing a `Pundit::NotAuthorizedError`?

Closes #20 and #32.
