### PR TITLE
AuthorizationNotPerformedError exception when action not verified

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -6,6 +6,7 @@ require "active_support/core_ext/object/blank"
 
 module Pundit
   class NotAuthorizedError < StandardError; end
+  class AuthorizationNotPerformedError < StandardError; end
   class NotDefinedError < StandardError; end
 
   extend ActiveSupport::Concern
@@ -45,11 +46,11 @@ module Pundit
   end
 
   def verify_authorized
-    raise NotAuthorizedError unless @_policy_authorized
+    raise AuthorizationNotPerformedError unless @_policy_authorized
   end
 
   def verify_policy_scoped
-    raise NotAuthorizedError unless @_policy_scoped
+    raise AuthorizationNotPerformedError unless @_policy_scoped
   end
 
   def authorize(record, query=nil)


### PR DESCRIPTION
Use `AuthorizationNotPerformedError` exception instead of `NotAuthorizedError` for the 2 methods `verify_authorized` and `verify_policy_scoped`, in order to allow clearer specs output messages
