### PR TITLE
Allow to use custom scope other than default Scope#resolve

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -11,13 +11,13 @@ module Pundit
   extend ActiveSupport::Concern
 
   class << self
-    def policy_scope(user, scope)
+    def policy_scope(user, scope, named = nil)
       policy = PolicyFinder.new(scope).scope
-      policy.new(user, scope).resolve if policy
+      call_named_scope(policy.new(user, scope), named) if policy
     end
 
-    def policy_scope!(user, scope)
-      PolicyFinder.new(scope).scope!.new(user, scope).resolve
+    def policy_scope!(user, scope, named = nil)
+      call_named_scope(PolicyFinder.new(scope).scope!.new(user, scope), named)
     end
 
     def policy(user, record)
@@ -27,6 +27,16 @@ module Pundit
 
     def policy!(user, record)
       PolicyFinder.new(record).policy!.new(user, record)
+    end
+  
+  private
+
+    def call_named_scope(scope, named)
+      if named
+        scope.send(named)
+      else
+        scope.resolve
+      end
     end
   end
 
@@ -61,9 +71,9 @@ module Pundit
     true
   end
 
-  def policy_scope(scope)
+  def policy_scope(scope, named = nil)
     @_policy_scoped = true
-    Pundit.policy_scope!(pundit_user, scope)
+    Pundit.policy_scope!(current_user, scope, named)
   end
 
   def policy(record)


### PR DESCRIPTION
The default behaviour is maintain, and `policy_scope(Class)` will call `ClassPolicy::Scope#resolve`

This add the possibility to create additional scopes `ClassPolicy::Scope#my_scope` for example, and call them with `policy_scope(Class, :my_scope)`

If the named scope is not defined i.e when calling `policy_scope(Class, :wrong_name)`, a NoMethodError is raised
