### PR TITLE
Allow policies to be injected into controllers.

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -63,8 +63,9 @@ module Pundit
 
   def policy_scope(scope)
     @_policy_scoped = true
-    Pundit.policy_scope!(pundit_user, scope)
+    @policy_scope or Pundit.policy_scope!(pundit_user, scope)
   end
+  attr_writer :policy_scope
 
   def policy(record)
     @policy or Pundit.policy!(pundit_user, record)

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -259,5 +259,12 @@ describe Pundit do
     it "throws an exception if the given policy can't be found" do
       expect { controller.policy_scope(Article) }.to raise_error(Pundit::NotDefinedError)
     end
+
+    it "allows policy_scope to be injected" do
+      new_scope = OpenStruct.new
+      controller.policy_scope = new_scope
+
+      controller.policy_scope(post).should == new_scope
+    end
   end
 end


### PR DESCRIPTION
In controller specs instead of relying on Pundit to instantiate the correct policy object allow it to be injected into the controller. More often than not a double is used in controller specs which means the policy cannot be inferred. This also allows us to double the policy to ensure that on a unit level the right methods are being called.

``` ruby
class PostsController < ApplicationController
  attr_writer :post
  helper_method :post

  def create
    authorize post

    post.save
    respond_with post
  end

  private

  def post
    @post ||= Post.new post_attributes
  end
end

describe PagesController do
  let(:policy) { double 'SomePolicy', create?: true }

  before do
    controller.policy = policy
  end

  it 'delegates authorization to policy' do
    expect(policy).to have_received(:create?)
  end
end
```
