### PR TITLE
Add note on avoiding DoubleRenderError in Rails to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,10 @@ class ApplicationController < ActionController::Base
   private
 
   def user_not_authorized
+    # Clear the previous response body to avoid a DoubleRenderError
+    # when redirecting or rendering another view
+    self.response_body = nil
+
     flash[:error] = "You are not authorized to perform this action."
     redirect_to request.headers["Referer"] || root_path
   end


### PR DESCRIPTION
When a `Pundit::NotAuthorizedError` is raised in an `after_action` (Rails 4)/ `after_filter` (Rails 3), the response has already been rendered.

To avoid a `DoubleRenderError` being raised, the response body can be cleared before redirecting or rendering a new view. 

Tested only in the browser in Rails 4.0. Fixes #52.

Please add a comment if you know another solution so we can work it in.
