### PR TITLE
Add Ruby 2.0 on Travis, drop Ruby 1.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.2
   - 1.9.3
+  - 2.0.0
   - jruby-19mode
   - rbx-19mode


### PR DESCRIPTION
Syncs supported ruby versions with [rails master](https://github.com/rails/rails/blob/master/.travis.yml), too.
