### PR TITLE
Use RSpec double syntax over stub to fix deprecation warning

### DIFF
--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -56,11 +56,11 @@ class ArticleTag
 end
 
 describe Pundit do
-  let(:user) { stub }
+  let(:user) { double }
   let(:post) { Post.new(user) }
   let(:comment) { Comment.new }
   let(:article) { Article.new }
-  let(:controller) { stub(:current_user => user, :params => { :action => "update" }).tap { |c| c.extend(Pundit) } }
+  let(:controller) { double(:current_user => user, :params => { :action => "update" }).tap { |c| c.extend(Pundit) } }
   let(:artificial_blog) { ArtificialBlog.new }
   let(:article_tag) { ArticleTag.new }
 


### PR DESCRIPTION
Fixes warnings: `DEPRECATION: stub is deprecated. Use double instead.`
