### PR TITLE
Fix to the Scope section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ PostPolicy = Struct.new(:user, :post) do
   Scope = Struct.new(:user, :scope) do
     def resolve
       if user.admin?
-        scope
+        scope.all
       else
         scope.where(:published => true)
       end


### PR DESCRIPTION
I am pretty sure the admin scope only works if I use scope.all in line 163 instead of just scope. Please let me know if there's something I am missing.
