### PR TITLE
Policy helper for rspec view specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ end
 
 ## RSpec
 
+### Policy Specs
+
 Pundit includes a mini-DSL for writing expressive tests for your policies in RSpec.
 Require `pundit/rspec` in your `spec_helper.rb`:
 
@@ -383,6 +385,36 @@ end
 
 An alternative approach to Pundit policy specs is scoping them to a user context as outlined in this
 [excellent post](http://thunderboltlabs.com/blog/2013/03/27/testing-pundit-policies-with-rspec/).
+
+### View Specs
+
+When writing view specs, you'll notice that the policy helper is not available
+and views under test that use it will fail. Thankfully, it's very easy to stub
+out the policy to have it return whatever is appropriate for the spec.
+
+``` ruby
+describe "users/show" do
+  before(:each) do
+    user = assign(:user, build_stubbed(:user))
+    controller.stub(:current_user).and_return user
+  end
+ 
+  it "renders the destroy action" do
+    allow(view).to receive(:policy).and_return double(edit?: false, destroy?: true)
+ 
+    render
+    expect(rendered).to match 'Destroy'
+  end
+end
+```
+
+This technique enables easy unit testing of tricky conditionaly view logic
+based on what is or is not authorized.
+
+# External Resources
+
+- [Migrating to Pundit from CanCan](http://blog.carbonfive.com/2013/10/21/migrating-to-pundit-from-cancan/)
+- [Testing Pundit Policies with RSpec](http://thunderboltlabs.com/blog/2013/03/27/testing-pundit-policies-with-rspec/)
 
 # License
 


### PR DESCRIPTION
I use rspec for testing and write view specs on some projects. Using Pundit's `policy` helper in views to conditionally render markup works great in a running application, but fails when running view specs because the helper isn't available.

> ActionView::Template::Error: undefined method `policy'

I could define a helper in each view spec [using this technique](https://www.relishapp.com/rspec/rspec-rails/v/2-0/docs/view-specs/view-spec#spec-with-view-that-accesses-helper-method-helpers), but that feels a little cumbersome.

Can you recommend a best practice for stubbing out the policy helper for view specs? Is there an opportunity to add something to pundit to make this easier, or to have it work out-of-the-box given some assumptions?
