### PR TITLE
Allow setting custom error messages in policies

### DIFF
--- a/spec/locales/en.yml
+++ b/spec/locales/en.yml
@@ -1,0 +1,5 @@
+en:
+  pundit:
+    default: "You are not allowed to perform this action."
+    post:
+      update: "You can only update your own posts."

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -25,15 +25,7 @@ class Post < Struct.new(:user)
   end
 end
 
-class CommentPolicy < Struct.new(:user, :comment)
-  def create?
-    false
-  end
-
-  def create_failed_message
-    "You cannot comment on this post."
-  end
-end
+class CommentPolicy < Struct.new(:user, :comment); end
 
 class CommentPolicy::Scope < Struct.new(:user, :scope)
   def resolve
@@ -72,6 +64,10 @@ describe Pundit do
   let(:controller) { double(:current_user => user, :params => { :action => "update" }).tap { |c| c.extend(Pundit) } }
   let(:artificial_blog) { ArtificialBlog.new }
   let(:article_tag) { ArticleTag.new }
+
+  before(:all) do
+    I18n.config.backend.load_translations('spec/locales/en.yml')
+  end
 
   describe ".policy_scope" do
     it "returns an instantiated policy scope given a plain model class" do
@@ -231,12 +227,11 @@ describe Pundit do
     end
 
     it "raises an error when the permission check fails" do
-      standard_error_message = "You are not allowed to perform this action."
-      expect { controller.authorize(Post.new) }.to raise_error(Pundit::NotAuthorizedError, standard_error_message)
+      expect { controller.authorize(Post.new) }.to raise_error(Pundit::NotAuthorizedError)
     end
 
-    it "raises an error with a custom error message if defined on the policy" do
-      expect { controller.authorize(comment, :create?) }.to raise_error(Pundit::NotAuthorizedError, CommentPolicy.new.create_failed_message)
+    it "raises an error with a custom error message if defined in the I18n locale file" do
+      expect { controller.authorize(Post.new) }.to raise_error(Pundit::NotAuthorizedError, I18n.t('pundit.post.update'))
     end
   end
 


### PR DESCRIPTION
**Update: See updated syntax in comment below.**

Regarding the subject of custom error messages, we've so far established a few boundaries:
- An authorization query can fail for multiple reasons, so one query might need different error messages.
- User facing errors should be presented in the user's language.

How about keeping the logic that selects error messages in the policies.

``` ruby
PostPolicy < ApplicationPolicy
  def create?
    user.admin? or not post.published?
  end

  def create_failed_message
    "You cannot create a published post unless you are an admin."
  end
end
```

With `I18n` (`I18n` is not introduced as a dependency):

``` ruby
PostPolicy < ApplicationPolicy
  def create?
    user.admin? or not post.published?
  end

  def create_failed_message
    # You can branch here if you need to select 
    # error messages based on certain conditions
    I18n.t( "pundit.posts.create")
  end
end
```

@jnicklas What do you think of the underlying idea?

Related to #38 and #66.

_Updated_: Updated error message method name to `#{query_without_?}_failed_message`.
