### PR TITLE
Fix a broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ end
 
 ## Rescuing a denied Authorization in Rails
 
-Pundit raises a `Pundit::NotAuthorizedError` you can [rescue_from](http://guides.rubyonrails.org/action_controller_overview.html#rescue_from) in your `ApplicationController`. You can customize the `user_not_authorized` method in every controller.
+Pundit raises a `Pundit::NotAuthorizedError` you can [rescue_from](http://guides.rubyonrails.org/action_controller_overview.html#rescue-from) in your `ApplicationController`. You can customize the `user_not_authorized` method in every controller.
 
 ```ruby
 class ApplicationController < ActionController::Base


### PR DESCRIPTION
The link to documentation about `rescue_from` used to point to this:

http://guides.rubyonrails.org/action_controller_overview.html#rescue_from

When it should be pointing to this:

http://guides.rubyonrails.org/action_controller_overview.html#rescue-from

(Note the hyphen instead of underscore at the end.)

Also, thanks for making such a great library! I look forward to using pundit instead of cancan.
