### PR TITLE
README: Fix Scope definition example

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ define a class called a policy scope. It can look something like this:
 
 ``` ruby
 PostPolicy = Struct.new(:user, :post) do
-  Scope = Struct.new(:user, :scope) do
+  self::Scope = Struct.new(:user, :scope) do
     def resolve
       if user.admin?
         scope.all


### PR DESCRIPTION
On Ruby 2.0.0 and Rails 4.0.0:

```
Foo = Struct.new(:foo) do
  Bar = Struct.new(:bar) do
  end
end
```

irb: `warning: toplevel constant Bar referenced by Foo::Bar`
Rails doesn't find the contant

We need to either use a class definition for `Foo` (`class Foo < Struct.new(:foo)`), or explicitly encapslulate `Bar`:

```
Foo = Struct.new(:foo) do
  self::Bar = Struct.new(:bar) do
  end
end
```
