### PR TITLE
Rename PostablePolicyClass to PostablePolicy in README for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ class, instead of letting Pundit infer it. This can be done like so:
 ``` ruby
 class Post
   def self.policy_class
-    PostablePolicyClass
+    PostablePolicy
   end
 end
 ```


### PR DESCRIPTION
This is a small change, but the example confused me. I thought the convention was to add "Class" at the end.

I was getting an error along the lines of "uninitialized constant Post::PostablePolicyClass" which makes pretty clear what's going on, but it still took be a few minutes to debug.
