### PR TITLE
update #authorize to be able to pass additional arguments to policy methods

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -52,10 +52,17 @@ module Pundit
     raise NotAuthorizedError unless @_policy_scoped
   end
 
-  def authorize(record, query=nil)
-    query ||= params[:action].to_s + "?"
+  def authorize(record, query_or_hash=nil)
+    case query_or_hash
+    when ->(qh){ qh.is_a?(NilClass) }
+      query = [params[:action].to_s + "?"]
+    when ->(qh){ qh.is_a?(Hash) }
+      query = query_or_hash.first
+    else
+      query = [query_or_hash]
+    end
     @_policy_authorized = true
-    unless policy(record).public_send(query)
+    unless policy(record).public_send(*query)
       raise NotAuthorizedError, "not allowed to #{query} this #{record}"
     end
     true

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -13,6 +13,9 @@ class PostPolicy < Struct.new(:user, :post)
   def show?
     true
   end
+  def index?(related_record)
+    related_record.true?
+  end
 end
 class PostPolicy::Scope < Struct.new(:user, :scope)
   def resolve
@@ -214,6 +217,10 @@ describe Pundit do
     it "can be given a different permission to check" do
       controller.authorize(post, :show?).should be_true
       expect { controller.authorize(post, :destroy?) }.to raise_error(Pundit::NotAuthorizedError)
+    end
+
+    it "can pass argument to permission check" do
+      controller.authorize(post, index?: double(:related_record, true?: true)).should be_true
     end
 
     it "works with anonymous class policies" do


### PR DESCRIPTION
I have a closed system where user shouldn't  see nested controller#index when he cannot access the parent controller #show 

so something like: `cats/123/caught_mouses`

so there is one  way to do it  

```
class CaughtMousesController < ApplicationControllerd
   def index
      @mouses = @cat.mouses.
      authorize(@cat)
      authorize(@mouses)
   end
end
```

but I think this way I'm shifting responsibility of determining correct access from policy to controller, 
and yes, in this case all I have to do is just `authorize(@cat)` but what about `cats/123/caught_mouses/234/edit`  ... let say I can see cat 123 but non necessarily can edit caught mouse

so another way: 

```
class CaughtMousesController < ApplicationControllerd
   def index
      @cat.mouses.
      authorize(@mouses, index?: @cat)
   end
end

class CaughtMousePolicy

   def index?(related_cat)
      CatPolicy.new(user, related_cat).show?
   end
end
```

yes technically I can just allow the index and list no `caught_mouses` but I don't want to allow user to be able to load mice#index if he cannot see the cat

so this pull request is allowing you to pass additional argument to permission check
