### PR TITLE
Updated README to cover mass-assignment protection for the create method

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,9 @@ end
 In Rails 4 (or Rails 3.2 with the
 [strong_parameters](https://github.com/rails/strong_parameters) gem),
 mass-assignment protection is handled in the controller.
-Pundit helps you permit different users to set different attributes.
+Pundit helps you permit different users to set different attributes. Don't
+forget to provide your policy an instance of object or a class so correct
+permissions could be loaded.
 
 ```ruby
 # app/policies/post_policy.rb
@@ -351,7 +353,7 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(*policy(@post).permitted_attributes)
+    params.require(:post).permit(*policy(@post || Post).permitted_attributes)
   end
 end
 ```


### PR DESCRIPTION
If we call `permitted_attributes` method during `create` action an error will be risen since (in the context of example provided in README), `@post` instance variable is `nil`; since average `create` method looks something like this:

``` ruby
def create
  @post = Post.create(permitted_attributes)
end
```

To fix this without interfering with the pundit code, it will be enough to provide a valid non `nil` object to the policy method (so the correct policy could be loaded).
