### PR TITLE
different rspec matchers for should and should_not

### DIFF
--- a/lib/pundit/rspec.rb
+++ b/lib/pundit/rspec.rb
@@ -4,8 +4,12 @@ module Pundit
       extend ::RSpec::Matchers::DSL
 
       matcher :permit do |user, record|
-        match do |policy|
+        match_for_should do |policy|
           permissions.all? { |permission| policy.new(user, record).public_send(permission) }
+        end
+
+        match_for_should_not do |policy|
+          permissions.none? { |permission| policy.new(user, record).public_send(permission) }
         end
 
         failure_message_for_should do |policy|


### PR DESCRIPTION
Following code would pass if single permission passes and all other fail since negation of `permissions.all?` is `permission.any?`.

``` ruby
permissions :show?, :edit?, :update? do
  it { should_not permit(user, record) }
end
```

To solve it, we need different logic for `should` and `should_not` cases.
https://www.relishapp.com/rspec/rspec-expectations/v/2-3/docs/custom-matchers/define-matcher#matcher-with-separate-logic-for-should-and-should-not
