### PR TITLE
Raise a specific error if authorization was not verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,18 +272,29 @@ end
 
 Pundit raises a `Pundit::NotAuthorizedError` you can [rescue_from](http://guides.rubyonrails.org/action_controller_overview.html#rescue-from) in your `ApplicationController`. You can customize the `user_not_authorized` method in every controller.
 
+Optionally, `Pundit::UnverifiedAuthorizationError` may be handled specially to
+avoid a possible `AbstractController::DoubleRenderError` when using
+`verify_authorized` or `verify_policy_scoped` in an `after_filter`. In the
+example below this error is simply re-raised so that it always surfaces,
+giving more helpful error reports in development.
+
 ```ruby
 class ApplicationController < ActionController::Base
   protect_from_forgery
   include Pundit
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+  rescue_from Pundit::UnverifiedAuthorizationError, with: :authorization_unverified
 
   private
 
   def user_not_authorized
     flash[:error] = "You are not authorized to perform this action."
     redirect_to request.headers["Referer"] || root_path
+  end
+
+  def authorization_unverified
+    raise
   end
 end
 ```

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -6,6 +6,7 @@ require "active_support/core_ext/object/blank"
 
 module Pundit
   class NotAuthorizedError < StandardError; end
+  class UnverifiedAuthorizationError < NotAuthorizedError; end
   class NotDefinedError < StandardError; end
 
   extend ActiveSupport::Concern
@@ -45,11 +46,11 @@ module Pundit
   end
 
   def verify_authorized
-    raise NotAuthorizedError unless @_policy_authorized
+    raise UnverifiedAuthorizationError unless @_policy_authorized
   end
 
   def verify_policy_scoped
-    raise NotAuthorizedError unless @_policy_scoped
+    raise UnverifiedAuthorizationError unless @_policy_scoped
   end
 
   def authorize(record, query=nil)

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -191,7 +191,7 @@ describe Pundit do
     end
 
     it "raises an exception when not authorized" do
-      expect { controller.verify_authorized }.to raise_error(Pundit::NotAuthorizedError)
+      expect { controller.verify_authorized }.to raise_error(Pundit::UnverifiedAuthorizationError)
     end
   end
 
@@ -202,7 +202,7 @@ describe Pundit do
     end
 
     it "raises an exception when policy_scope is not used" do
-      expect { controller.verify_policy_scoped }.to raise_error(Pundit::NotAuthorizedError)
+      expect { controller.verify_policy_scoped }.to raise_error(Pundit::UnverifiedAuthorizationError)
     end
   end
 


### PR DESCRIPTION
This change makes the methods `verify_authorized` and `verify_policy_scoped` raise a new error type, `Pundit::UnverifiedAuthorizationError`, which inherits from `Pundit::NotAuthorizedError`, instead of just raising a `Pundit::NotAuthorizedError`.

This allows this condition to be handled specially, for example to handle more gracefully the Rails issue described in #52 and #53. I have updated the Rails section of the README with this suggestion.
