### PR TITLE
Add note to readme to explain DoubleRenderError

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ class ApplicationController < ActionController::Base
 end
 ```
 
+Both these methods may lead to a `DoubleRenderError` if you use Rails and
+actually did not call `authorize` since most controllers already call `render`
+beforehand.
+
+
 ## Scopes
 
 Often, you will want to have some kind of view listing records which a


### PR DESCRIPTION
Since there have been a few issues opened on the subject I propose to modify  the readme to reflect the potential `DoubleRenderError` that Rails users might encounter using `verify_policy_scoped` and `verify_authorized`.
