### PR TITLE
Raise a different error when authorization is not performed

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,6 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-Both these methods may lead to a `DoubleRenderError` if you use Rails and
-actually did not call `authorize` since most controllers already call `render`
-beforehand.
-
-
 ## Scopes
 
 Often, you will want to have some kind of view listing records which a

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -6,6 +6,7 @@ require "active_support/core_ext/object/blank"
 
 module Pundit
   class NotAuthorizedError < StandardError; end
+  class AuthorizationNotPerformedError < StandardError; end
   class NotDefinedError < StandardError; end
 
   extend ActiveSupport::Concern
@@ -45,11 +46,11 @@ module Pundit
   end
 
   def verify_authorized
-    raise NotAuthorizedError unless @_policy_authorized
+    raise AuthorizationNotPerformedError unless @_policy_authorized
   end
 
   def verify_policy_scoped
-    raise NotAuthorizedError unless @_policy_scoped
+    raise AuthorizationNotPerformedError unless @_policy_scoped
   end
 
   def authorize(record, query=nil)

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -191,7 +191,7 @@ describe Pundit do
     end
 
     it "raises an exception when not authorized" do
-      expect { controller.verify_authorized }.to raise_error(Pundit::NotAuthorizedError)
+      expect { controller.verify_authorized }.to raise_error(Pundit::AuthorizationNotPerformedError)
     end
   end
 
@@ -202,7 +202,7 @@ describe Pundit do
     end
 
     it "raises an exception when policy_scope is not used" do
-      expect { controller.verify_policy_scoped }.to raise_error(Pundit::NotAuthorizedError)
+      expect { controller.verify_policy_scoped }.to raise_error(Pundit::AuthorizationNotPerformedError)
     end
   end
 


### PR DESCRIPTION
Authorization should always be performed before rendering, so `authorize` should under normal circumstances not lead to a `DoubleRenderError`. As noted in the README addition added in #108, `verify_authorized` is performed in an after filter, after rendering has already been performed. This leads to `DoubleRenderError` when the user has specified a `rescue_from Pundit::NotAuthorizedError` in their controller.

The way around this is to simply raise a different exception. Since you never want this exception to happen in production anyway, there's no need to add a `rescue_from` clause for this error, and so the `DoubleRenderError` problem is no longer relevant.
