### PR TITLE
Don't run specs on Rubinius on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,3 @@ rvm:
   - 2.0.0
   - 2.1.0
   - jruby-19mode
-  - rbx


### PR DESCRIPTION
Looks to me that RBX on Travis failures

```
$ bundle exec rake
An exception occurred running /home/travis/.rvm/rubies/rbx-2.2.3/gems/bin/rake:
    no such file to load -- singleton (LoadError)
```

are unrelated to Pundit. Does anyone have a hint?

[Recently failing Pundit build on Travis](https://travis-ci.org/elabs/pundit/jobs/18877348)

Seems like there are a few open issues already, like [rubinius/rubinus#2790](https://github.com/rubinius/rubinius/issues/2790). This issue doesn't seems Pundit related, so we can add support for RBX back in when it's resolved upstream.
