### PR TITLE
Add #query and #record properties to Pundit::NotAuthorizedError.

### DIFF
--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -224,6 +224,14 @@ describe Pundit do
     it "raises an error when the permission check fails" do
       expect { controller.authorize(Post.new) }.to raise_error(Pundit::NotAuthorizedError)
     end
+
+    it "raises an error with a query and action" do
+      expect { controller.authorize(post, :destroy?) }.to raise_error do |error|
+        expect(error.query).to eq :destroy?
+        expect(error.record).to eq post
+        expect(error.policy).to eq controller.policy(post)
+      end
+    end
   end
 
   describe "#pundit_user" do


### PR DESCRIPTION
I don't see why `Pundit::NotAuthorizedError` doesn't provide the user with the query or record that "caused" the error to be raised. This PR adds these two properties.

I think using the `NotAuthorizedError` could resolve the still-open question of handling custom error messages (see #68, #38, and #66 for earlier discussion). With this change, I as a user of this gem could choose to (but am not obligated to) use the query and record property to create my error message:

``` ruby
class ApplicationController < ActionController::Base
  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized

  def user_not_authorized(exception)
    record_name = exception.record.class.to_s.downcase
    flash[:error] = I18n.t "pundit.#{record_name}.#{exception.query}"
  end
end
```

``` yaml
en:
  pundit:
    post:
      update?: 'You cannot edit this post!'
```

I think one of the strong points about Pundit is that it is extremely transparent -- there's almost nothing magical about it. The fact that there's little consensus about how errors should be handled is a sign that we can't predict what developers will expect Pundit to do w.r.t. errors. Rather than surprise them, why not let developers choose how to handle errors on their own?

Let me know what you think!
