### PR TITLE
Extend NotAuthorizedError with policy, record and query

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -6,7 +6,7 @@ require "active_support/core_ext/object/blank"
 
 module Pundit
   class NotAuthorizedError < StandardError
-    attr_accessor :user, :record, :query
+    attr_accessor :policy, :record, :query
   end
   class NotDefinedError < StandardError; end
 
@@ -59,7 +59,7 @@ module Pundit
     @_policy_authorized = true
     unless policy(record).public_send(query)
       e = NotAuthorizedError.new
-      e.user, e.record, e.query = policy(record).user, record, query
+      e.policy, e.record, e.query = policy(record), record, query
       raise e, "not allowed to #{query} this #{record}"
     end
     true

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -225,9 +225,9 @@ describe Pundit do
       expect { controller.authorize(Post.new) }.to raise_error(Pundit::NotAuthorizedError)
     end
 
-    it "raises an error with a user, record and query" do
+    it "raises an error with a policy, record and query" do
       expect { controller.authorize(post, :destroy?) }.to raise_error do |error|
-        expect(error.user).to eq user
+        expect(error.policy).to eq controller.policy(post)
         expect(error.record).to eq post
         expect(error.query).to eq :destroy?
         expect(error.message).to eq "not allowed to #{error.query} this #{error.record}"


### PR DESCRIPTION
#114 is the real thing. Just a test whether passing in a message to `e = Exception.new; raise e` works on all supported Ruby runtimes.
