### PR TITLE
add link to RailsApps example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ based on what is or is not authorized.
 
 # External Resources
 
+- [RailsApps Example Application: Pundit and Devise](https://github.com/RailsApps/rails-devise-pundit)
 - [Migrating to Pundit from CanCan](http://blog.carbonfive.com/2013/10/21/migrating-to-pundit-from-cancan/)
 - [Testing Pundit Policies with RSpec](http://thunderboltlabs.com/blog/2013/03/27/testing-pundit-policies-with-rspec/)
 


### PR DESCRIPTION
In response to requests for examples of Pundit integrated with Devise, the RailsApps project has released the rails-devise-pundit example application. This could be a good resource to list under the "External Resources" heading in the README.
