### PR TITLE
Add Scope class to generator

### DIFF
--- a/lib/generators/pundit/install/templates/application_policy.rb
+++ b/lib/generators/pundit/install/templates/application_policy.rb
@@ -37,5 +37,18 @@ class ApplicationPolicy
   def scope
     Pundit.policy_scope!(user, record.class)
   end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope
+    end
+  end
 end
 


### PR DESCRIPTION
Method `policy_scope!` doesn't work without defined class `Scope`.

So, I suggest to add this class to generator.
