### PR TITLE
add stand-alone authorizer

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -1,4 +1,5 @@
 require "pundit/version"
+require "pundit_authorizer"
 require "pundit/policy_finder"
 require "active_support/concern"
 require "active_support/core_ext/string/inflections"

--- a/lib/pundit_authorizer.rb
+++ b/lib/pundit_authorizer.rb
@@ -1,0 +1,52 @@
+# This is a stand alone authorizer without any
+# dependency on controller.
+#
+# It is very useful on service object.
+#
+# Example usage:
+#
+#   authorizer = PunditAuthorizer.new(user, post)
+#   authorizer.authorize_on 'create'
+#
+# Example on a service object
+#
+#   class PostCreator
+#     attr_reader :user, :post
+#     def initialize(user, params)
+#       @user = user
+#       @post = Post.new(params)
+#     end
+#
+#     def create
+#       authorize_post
+#       save_post
+#       process_things_after_save
+#     end
+#
+#     def authorize_post
+#       authorizer = PunditAuthorizer.new(user, post)
+#       authorizer.authorize_on 'create'
+#     end
+class PunditAuthorizer
+  include Pundit
+
+  attr_reader :user, :obj
+
+  def initialize(user, obj)
+    @user = user
+    @obj  = obj
+  end
+
+  # The only API
+  # query can end with '? optionally
+  def authorize_on(query)
+    query += '?' unless query.last == '?'
+    authorize(obj, query)
+  end
+
+  private
+  # Override Pundit to refer user to @user, instead of current_user
+  def pundit_user
+    user
+  end
+end


### PR DESCRIPTION
I found a stand alone authorizer is desired sometimes, when there is no involvement of controller.

I've wrote such class in my app's lib and being quite happy to use it for days. I guess the main repo may need this as well to provide more support to service object.

Test and doc can be added later if the idea is okay.
