### PR TITLE
Better error handling when searching for policy_class method

### DIFF
--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -31,22 +31,33 @@ module Pundit
   private
 
     def find
-      if object.respond_to?(:policy_class)
+      if policy_class_defined?(object)
         object.policy_class
-      elsif object.class.respond_to?(:policy_class)
+      elsif policy_class_defined?(object.class)
         object.class.policy_class
       else
-        klass = if object.respond_to?(:model_name)
-          object.model_name
-        elsif object.class.respond_to?(:model_name)
-          object.class.model_name
-        elsif object.is_a?(Class)
-          object
-        else
-          object.class
-        end
-        "#{klass}Policy"
+        "#{class_name_for_policy}Policy"
       end
+    end
+
+    def class_name_for_policy
+      if model_name_defined?(object)
+        object.model_name
+      elsif model_name_defined?(object.class)
+        object.class.model_name
+      elsif object.is_a?(Class)
+        object
+      else
+        object.class
+      end
+    end
+
+    def policy_class_defined?(object_to_check)
+      object_to_check.public_methods.include?(:policy_class)
+    end
+
+    def model_name_defined?(object_to_check)
+      object_to_check.public_methods.include?(:model_name)
     end
   end
 end

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -8,6 +8,7 @@ describe Pundit do
   let(:controller) { double(:current_user => user, :params => { :action => "update" }).tap { |c| c.extend(Pundit) } }
   let(:artificial_blog) { ArtificialBlog.new }
   let(:article_tag) { ArticleTag.new }
+  let(:protected_policy_instance) { ModelWithProtectedPolicy.new }
 
   describe ".policy_scope" do
     it "returns an instantiated policy scope given a plain model class" do
@@ -96,6 +97,12 @@ describe Pundit do
         expect(policy.tag).to eq ArticleTag
       end
     end
+
+    context 'when the policy class method is protected' do
+      it 'should return nil' do
+        expect(Pundit.policy(user, protected_policy_instance)).to be_nil
+      end
+    end
   end
 
   describe ".policy!" do
@@ -126,6 +133,12 @@ describe Pundit do
     it "throws an exception if the given policy can't be found" do
       expect { Pundit.policy!(user, article) }.to raise_error(Pundit::NotDefinedError)
       expect { Pundit.policy!(user, Article) }.to raise_error(Pundit::NotDefinedError)
+    end
+
+    context 'when the policy class method is protected' do
+      it 'should throw an exception' do
+        expect { Pundit.policy!(user, protected_policy_instance) }.to raise_error(Pundit::NotDefinedError)
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,3 +54,9 @@ class ArticleTag
     end
   end
 end
+class ModelWithProtectedPolicy
+  protected
+  def policy_class
+    BlogPolicy
+  end
+end


### PR DESCRIPTION
In Ruby 1.9.3 Object#respond_to? can return true even if the method is not defined on the public interface of the object. This can happen if for some reason the policy_class method was protected. This PR should change the error being raised from:

```
NoMethodError - undefined method `policy_class' for #<Class:0x00000009a55f38>
...
pundit (0.2.3) lib/pundit/policy_finder.rb:35:in `find'
pundit (0.2.3) lib/pundit/policy_finder.rb:28:in `policy!'
...
```

to the more useful error:

```
Pundit::NotDefinedError - unable to find policy SomePolicy
```
