### PR TITLE
Policy instance variable and writer

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -82,9 +82,12 @@ module Pundit
   attr_writer :policy_scope
 
   def policy(record)
-    @policy or Pundit.policy!(pundit_user, record)
+    @_policy or Pundit.policy!(pundit_user, record)
   end
-  attr_writer :policy
+
+  def policy=(policy)
+    @_policy = policy
+  end
 
   def pundit_user
     current_user


### PR DESCRIPTION
This changes the `@policy` instance variable to `@_policy`. `attr_writer :policy` has been replaced with a method writing to `@_policy` underneath, which keeps the `policy=` method available for injecting a policy and avoids any changes to the specs.

We work on a number of insurance apps, which usually have a Policy model. This PR comes about after trying to authorize a policy in a PoliciesController: `authorize @policy`. In this case, Pundit's `policy` method always returns the Policy instance in `@policy`, rather than its policy (amusingly named `PolicyPolicy`).

Rather than changing the instance variable in our app, I thought Pundit could follow the pattern it already uses for some instance variables such as `@_policy_scoped`.

Interested to hear your opinions on this change. This is my 1st time using Pundit, so if you can recommend a better way of going about this I'd like to hear it.
