### PR TITLE
require activemodel instead of activerecord

### DIFF
--- a/pundit.gemspec
+++ b/pundit.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "activesupport", ">= 3.0.0"
-  gem.add_development_dependency "activerecord", ">= 3.0.0"
+  gem.add_development_dependency "activemodel", ">= 3.0.0"
   gem.add_development_dependency "bundler", "~> 1.3"
   gem.add_development_dependency "rspec", "~>3.0.0.beta1"
   gem.add_development_dependency "pry"


### PR DESCRIPTION
activerecord is not a development dependency
