### PR TITLE
Use `rbx-2` in .travis.yml due to regression in rvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
   - 2.0.0
   - 2.1.0
   - jruby-19mode
-  - rbx
+  - rbx-2


### PR DESCRIPTION
See:
https://twitter.com/travisci/status/467072346231025665
