### PR TITLE
Using Struct properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ end
 ```
 
 As you can see, this is just a plain Ruby class. As a convenience, we can inherit
-from Struct or use Struct.new to define the policy class:
+from Struct using Struct.new to define the policy class:
 
 ``` ruby
-class PostPolicy < Struct.new(:user, :post)
+PostPolicy = Struct.new(:user, :post) do
   def update?
     user.admin? or not post.published?
   end
@@ -161,19 +161,19 @@ particular user has access to. When using Pundit, you are expected to
 define a class called a policy scope. It can look something like this:
 
 ``` ruby
-class PostPolicy < Struct.new(:user, :post)
-  class Scope < Struct.new(:user, :scope)
-    def resolve
-      if user.admin?
-        scope.all
-      else
-        scope.where(:published => true)
-      end
-    end
-  end
-
+PostPolicy = Struct.new(:user, :post) do
   def update?
     user.admin? or not post.published?
+  end
+end
+
+PostPolicy::Scope = Struct.new(:user, :scope) do
+  def resolve
+    if user.admin?
+      scope.all
+    else
+      scope.where(:published => true)
+    end
   end
 end
 ```

--- a/lib/generators/pundit/policy/templates/policy.rb
+++ b/lib/generators/pundit/policy/templates/policy.rb
@@ -1,6 +1,6 @@
 <% module_namespacing do -%>
 class <%= class_name %>Policy < ApplicationPolicy
-  class Scope < Struct.new(:user, :scope)
+  Scope = Struct.new(:user, :scope) do
     def resolve
       scope
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require "pry"
 require "active_support/core_ext"
 require "active_model/naming"
 
-class PostPolicy < Struct.new(:user, :post)
+PostPolicy = Struct.new(:user, :post) do
   def update?
     post.user == user
   end
@@ -14,19 +14,19 @@ class PostPolicy < Struct.new(:user, :post)
     true
   end
 end
-class PostPolicy::Scope < Struct.new(:user, :scope)
+PostPolicy::Scope = Struct.new(:user, :scope) do
   def resolve
     scope.published
   end
 end
-class Post < Struct.new(:user)
+Post = Struct.new(:user) do
   def self.published
     :published
   end
 end
 
-class CommentPolicy < Struct.new(:user, :comment); end
-class CommentPolicy::Scope < Struct.new(:user, :scope)
+CommentPolicy = Struct.new(:user, :comment)
+CommentPolicy::Scope = Struct.new(:user, :scope) do
   def resolve
     scope
   end
@@ -35,7 +35,7 @@ class Comment; extend ActiveModel::Naming; end
 
 class Article; end
 
-class BlogPolicy < Struct.new(:user, :blog); end
+BlogPolicy = Struct.new(:user, :blog)
 class Blog; end
 class ArtificialBlog < Blog
   def self.policy_class
@@ -67,7 +67,7 @@ class Controller
 end
 
 module Admin
-  class CommentPolicy < Struct.new(:user, :comment); end
+  CommentPolicy = Struct.new(:user, :comment)
   class Controller
     include Pundit
 


### PR DESCRIPTION
This proposal is based in this doc: http://www.ruby-doc.org/core-2.1.2/Struct.html

> This is the recommended way to customize a struct. Subclassing an anonymous struct creates an extra anonymous class that will never be used.

The difference can be observed below (notice the extra anonymous class in the ancestors chain):

``` ruby
class PostPolicy < Struct.new(:user, :post); end
PostPolicy.ancestors
#=> [PostPolicy, #<Class:0x00000101831010>, Struct, Enumerable, Object, PP::ObjectMixin, Kernel, BasicObject]
```

``` ruby
PostPolicy = Struct.new(:user, :post)
PostPolicy.ancestors
#=> [PostPolicy, Struct, Enumerable, Object, PP::ObjectMixin, Kernel, BasicObject]
```
