### PR TITLE
Remove RSpec3 deprecation warnings

### DIFF
--- a/lib/pundit/rspec.rb
+++ b/lib/pundit/rspec.rb
@@ -1,52 +1,5 @@
-module Pundit
-  module RSpec
-    module Matchers
-      extend ::RSpec::Matchers::DSL
-
-      matcher :permit do |user, record|
-        match_for_should do |policy|
-          permissions.all? { |permission| policy.new(user, record).public_send(permission) }
-        end
-
-        match_for_should_not do |policy|
-          permissions.none? { |permission| policy.new(user, record).public_send(permission) }
-        end
-
-        failure_message_for_should do |policy|
-          "Expected #{policy} to grant #{permissions.to_sentence} on #{record} but it didn't"
-        end
-
-        failure_message_for_should_not do |policy|
-          "Expected #{policy} not to grant #{permissions.to_sentence} on #{record} but it did"
-        end
-
-        def permissions
-          current_example = ::RSpec.respond_to?(:current_example) ? ::RSpec.current_example : example
-          current_example.metadata[:permissions]
-        end
-      end
-    end
-
-    module DSL
-      def permissions(*list, &block)
-        describe(list.to_sentence, :permissions => list, :caller => caller) { instance_eval(&block) }
-      end
-    end
-
-    module PolicyExampleGroup
-      include Pundit::RSpec::Matchers
-
-      def self.included(base)
-        base.metadata[:type] = :policy
-        base.extend Pundit::RSpec::DSL
-        super
-      end
-    end
-  end
-end
-
-RSpec.configure do |config|
-  config.include Pundit::RSpec::PolicyExampleGroup, :type => :policy, :example_group => {
-    :file_path => /spec\/policies/
-  }
+if RSpec::Core::Version::STRING.starts_with?("3")
+  require 'pundit/rspec3'
+else
+  require 'pundit/rspec2'
 end

--- a/lib/pundit/rspec2.rb
+++ b/lib/pundit/rspec2.rb
@@ -1,0 +1,52 @@
+module Pundit
+  module RSpec
+    module Matchers
+      extend ::RSpec::Matchers::DSL
+
+      matcher :permit do |user, record|
+        match_for_should do |policy|
+          permissions.all? { |permission| policy.new(user, record).public_send(permission) }
+        end
+
+        match_for_should_not do |policy|
+          permissions.none? { |permission| policy.new(user, record).public_send(permission) }
+        end
+
+        failure_message_for_should do |policy|
+          "Expected #{policy} to grant #{permissions.to_sentence} on #{record} but it didn't"
+        end
+
+        failure_message_for_should_not do |policy|
+          "Expected #{policy} not to grant #{permissions.to_sentence} on #{record} but it did"
+        end
+
+        def permissions
+          current_example = ::RSpec.respond_to?(:current_example) ? ::RSpec.current_example : example
+          current_example.metadata[:permissions]
+        end
+      end
+    end
+
+    module DSL
+      def permissions(*list, &block)
+        describe(list.to_sentence, :permissions => list, :caller => caller) { instance_eval(&block) }
+      end
+    end
+
+    module PolicyExampleGroup
+      include Pundit::RSpec::Matchers
+
+      def self.included(base)
+        base.metadata[:type] = :policy
+        base.extend Pundit::RSpec::DSL
+        super
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include Pundit::RSpec::PolicyExampleGroup, :type => :policy, :example_group => {
+    :file_path => /spec\/policies/
+  }
+end

--- a/lib/pundit/rspec3.rb
+++ b/lib/pundit/rspec3.rb
@@ -1,0 +1,50 @@
+module Pundit
+  module RSpec
+    module Matchers
+      extend ::RSpec::Matchers::DSL
+
+      matcher :permit do |user, record|
+        match do |policy|
+          permissions.all? { |permission| policy.new(user, record).public_send(permission) }
+        end
+
+        match_when_negated do |policy|
+          permissions.none? { |permission| policy.new(user, record).public_send(permission) }
+        end
+
+        failure_message do |policy|
+          "Expected #{policy} to grant #{permissions.to_sentence} on #{record} but it didn't"
+        end
+
+        failure_message_when_negated do |policy|
+          "Expected #{policy} not to grant #{permissions.to_sentence} on #{record} but it did"
+        end
+
+        def permissions
+          current_example = ::RSpec.respond_to?(:current_example) ? ::RSpec.current_example : example
+          current_example.metadata[:permissions]
+        end
+      end
+    end
+
+    module DSL
+      def permissions(*list, &block)
+        describe(list.to_sentence, :permissions => list, :caller => caller) { instance_eval(&block) }
+      end
+    end
+
+    module PolicyExampleGroup
+      include Pundit::RSpec::Matchers
+
+      def self.included(base)
+        base.metadata[:type] = :policy
+        base.extend Pundit::RSpec::DSL
+        super
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include Pundit::RSpec::PolicyExampleGroup, :type => :policy, :file_path => /spec\/policies/
+end


### PR DESCRIPTION
Another one solution to eliminate deprecation warnings while using pundit rspec helper with rspec3. Includes backward compatibility with rspec2.

Thanks @noelrappin for the idea who proposed a fix for #150 in his pull request #156.
Resolves #148 and #150.
