### PR TITLE
Fix RSpec3 matcher deprecations

### DIFF
--- a/lib/pundit/rspec.rb
+++ b/lib/pundit/rspec.rb
@@ -4,20 +4,32 @@ module Pundit
       extend ::RSpec::Matchers::DSL
 
       matcher :permit do |user, record|
-        match_for_should do |policy|
+        match_proc = lambda do |policy|
           permissions.all? { |permission| policy.new(user, record).public_send(permission) }
         end
 
-        match_for_should_not do |policy|
+        match_when_negated_proc = lambda do |policy|
           permissions.none? { |permission| policy.new(user, record).public_send(permission) }
         end
 
-        failure_message_for_should do |policy|
+        failure_message_proc = lambda do |policy|
           "Expected #{policy} to grant #{permissions.to_sentence} on #{record} but it didn't"
         end
 
-        failure_message_for_should_not do |policy|
+        failure_message_when_negated_proc = lambda do |policy|
           "Expected #{policy} not to grant #{permissions.to_sentence} on #{record} but it did"
+        end
+
+        if respond_to?(:match_when_negated)
+          match(&match_proc)
+          match_when_negated(&match_when_negated_proc)
+          failure_message(&failure_message_proc)
+          failure_message_when_negated(&failure_message_when_negated_proc)
+        else
+          match_for_should(&match_proc)
+          match_for_should_not(&match_when_negated_proc)
+          failure_message_for_should(&failure_message_proc)
+          failure_message_for_should_not(&failure_message_when_negated_proc)
         end
 
         def permissions


### PR DESCRIPTION
This is an alternative solution to the one proposed in #160, without so much duplication. It has just +16/-4 lines compared to +106/-51. Also it's not issuing deprecations with RSpec 2.99. Of course it's still compatible with RSpec 2.14 and earlier.
