### PR TITLE
Raise more description exception for verify_policy_scoped

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -11,6 +11,7 @@ module Pundit
     attr_accessor :query, :record, :policy
   end
   class AuthorizationNotPerformedError < StandardError; end
+  class PolicyScopingNotPerformedError < AuthorizationNotPerformedError; end
   class NotDefinedError < StandardError; end
 
   extend ActiveSupport::Concern
@@ -58,7 +59,7 @@ module Pundit
   end
 
   def verify_policy_scoped
-    raise AuthorizationNotPerformedError unless @_policy_scoped
+    raise PolicyScopingNotPerformedError unless @_policy_scoped
   end
 
   def authorize(record, query=nil)

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -148,7 +148,7 @@ describe Pundit do
     end
 
     it "raises an exception when policy_scope is not used" do
-      expect { controller.verify_policy_scoped }.to raise_error(Pundit::AuthorizationNotPerformedError)
+      expect { controller.verify_policy_scoped }.to raise_error(Pundit::PolicyScopingNotPerformedError)
     end
   end
 


### PR DESCRIPTION
A friend recently came to me asking why his app was raising an error claiming that authorization was not performed when `authorize` was clearly being called. It took me a moment to guess that the same exception type was being used for both `verify_*` methods.

This struct me as counterintuitive and easily remedied by a more description error type for this case. My only concern was backward compatibility, which I opted to solve by making the new type a sub-type of the existing one. While this isn't a solution I love, it seemed like the simplest one.

Let me know what you think!
