### PR TITLE
Enable headless policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,26 @@ end
 When no namespaced policy can be found, Pundit falls back to using the
 non-namespaced policy.
 
+## Headless policies
+
+Given there is a policy without a corresponding model / ruby class, 
+you can retrieve it by passing a symbol.
+
+```ruby
+# app/policies/dashboard_policy.rb
+class DashboardPolicy < Struct.new(:user, :dashboard)
+  # ...
+end
+
+# In controllers
+authorize :dashboard, :show?
+
+# In views
+<% if policy(:dashboard).show? %>
+  <%= link_to 'Dashboard', dashboard_path %>
+<% end %>
+```
+
 ## Ensuring policies are used
 
 Pundit adds a method called `verify_authorized` to your controllers. This

--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -43,6 +43,8 @@ module Pundit
           object.class.model_name
         elsif object.is_a?(Class)
           object
+        elsif object.is_a?(Symbol)
+          object.to_s.classify
         else
           object.class
         end

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -96,6 +96,13 @@ describe Pundit do
         expect(policy.user).to eq user
         expect(policy.tag).to eq ArticleTag
       end
+
+      it "returns an instantiated policy given a symbol" do
+        policy = Pundit.policy(user, :dashboard)
+        expect(policy.class).to eq DashboardPolicy
+        expect(policy.user).to eq user
+        expect(policy.dashboard).to eq :dashboard
+      end
     end
   end
 
@@ -122,6 +129,13 @@ describe Pundit do
       policy = Pundit.policy!(user, Comment)
       expect(policy.user).to eq user
       expect(policy.comment).to eq Comment
+    end
+
+    it "returns an instantiated policy given a symbol" do
+      policy = Pundit.policy!(user, :dashboard)
+      expect(policy.class).to eq DashboardPolicy
+      expect(policy.user).to eq user
+      expect(policy.dashboard).to eq :dashboard
     end
 
     it "throws an exception if the given policy can't be found" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,6 +55,8 @@ class ArticleTag
   end
 end
 
+class DashboardPolicy < Struct.new(:user, :dashboard); end
+
 class Controller
   include Pundit
 


### PR DESCRIPTION
Enables **`policy(:dashboard) # => DashboardPolicy`**. 

Policies without a matching model can come in handy when a controller
isn't modeled alongside a resource, e.g. a `DashboardsController`.

The policy lookup by symbol also helps with strong parameters,
since I prefer `policy(:post)` or `policy(@post || :post)` over `policy(@post || Post)`.
