### PR TITLE
Fix rspec3 deprecation warning

### DIFF
--- a/lib/pundit/rspec.rb
+++ b/lib/pundit/rspec.rb
@@ -58,7 +58,5 @@ module Pundit
 end
 
 RSpec.configure do |config|
-  config.include Pundit::RSpec::PolicyExampleGroup, :type => :policy, :example_group => {
-    :file_path => /spec\/policies/
-  }
+  config.include Pundit::RSpec::PolicyExampleGroup, :type => :policy, :file_path => /spec\/policies/
 end


### PR DESCRIPTION
Filtering by an `:example_group` subhash is deprecated. Use the subhash to filter directly instead.
