### PR TITLE
Fix error with subhash

### DIFF
--- a/lib/pundit/rspec.rb
+++ b/lib/pundit/rspec.rb
@@ -58,7 +58,5 @@ module Pundit
 end
 
 RSpec.configure do |config|
-  config.include Pundit::RSpec::PolicyExampleGroup, :type => :policy, :example_group => {
-    :file_path => /spec\/policies/
-  }
+  config.include Pundit::RSpec::PolicyExampleGroup, type: :policy, file_path: /spec\/policies/
 end


### PR DESCRIPTION
I used pundit with rspec. And i had this warning

```
Deprecation Warnings:

Filtering by an `:example_group` subhash is deprecated. Use the subhash to filter directly instead. Called from /Users/vorob/Dropbox/ruby/bezagentstva.ru/vendor/bundle/ruby/2.1.0/bundler/gems/pundit-c2cd910f6b0e/lib/pundit/rspec.rb:61:in `block in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace. 
```

I hope my commit fix this issue)
