### PR TITLE
RSpec matchers pass arbitrary number of arguments to policy constructor

### DIFF
--- a/lib/pundit/rspec.rb
+++ b/lib/pundit/rspec.rb
@@ -5,13 +5,13 @@ module Pundit
     module Matchers
       extend ::RSpec::Matchers::DSL
 
-      matcher :permit do |user, record|
+      matcher :permit do |user, record, *args|
         match_proc = lambda do |policy|
-          permissions.all? { |permission| policy.new(user, record).public_send(permission) }
+          permissions.all? { |permission| policy.new(user, record, *args).public_send(permission) }
         end
 
         match_when_negated_proc = lambda do |policy|
-          permissions.none? { |permission| policy.new(user, record).public_send(permission) }
+          permissions.none? { |permission| policy.new(user, record, *args).public_send(permission) }
         end
 
         failure_message_proc = lambda do |policy|

--- a/spec/policies/author_policy_spec.rb
+++ b/spec/policies/author_policy_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe AuthorPolicy do
+  let(:user) { double(:user, email: "kelly@slater.com") }
+  let(:author) { double(:author, email: "kelly@slater.com") }
+  let(:website) { double(:website, owner: user) }
+  let(:other_website) { double(:website, owner: double(:other_user)) }
+  subject { AuthorPolicy }
+
+  permissions :update? do
+    it "is successful when the permissions of all arguments match" do
+      should permit(user, author, website)
+    end
+
+    it "fails when any permissions of any args do not match" do
+      should_not permit(user, author, other_website)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,19 @@ RSpec.configure do |config|
   config.include PunditSpecHelper
 end
 
+class AuthorPolicy < Struct.new(:user, :author)
+  attr_reader :website
+
+  def initialize(user, author, website)
+    super(user, author)
+    @website = website
+  end
+
+  def update?
+    user.email == author.email && website.owner == user
+  end
+end
+
 class PostPolicy < Struct.new(:user, :post)
   def update?
     post.user == user


### PR DESCRIPTION
This is useful if you ever have a complicated policy and manually set it in the controller
