### PR TITLE
Changes policy lookup to look at controller's namespace and then fallback to model's namespace

### DIFF
--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -10,6 +10,7 @@ describe Pundit do
   let(:artificial_blog) { ArtificialBlog.new }
   let(:article_tag) { ArticleTag.new }
   let(:nested_controller) { Admin::Controller.new }
+  let(:deep_nested_controller) { Api::V1::Admin::Controller.new }
 
   describe ".policy_scope" do
     it "returns an instantiated policy scope given a plain model class" do
@@ -215,6 +216,7 @@ describe Pundit do
     it "looks up the policy class based on the caller's namespace" do
       expect(nested_controller.policy(comment).class).to eq Admin::CommentPolicy
       expect(nested_controller.policy(nested_comment).class).to eq Admin::CommentPolicy
+      expect(deep_nested_controller.policy(nested_comment).class).to eq Admin::CommentPolicy
     end
 
     it "falls back to the non-namespaced policy class if there isn't a namespaced one" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,3 +107,14 @@ module Admin
     attr_reader :current_user, :params
   end
 end
+
+module Api
+  module V1
+    module Admin
+      class Controller
+        include Pundit
+        attr_reader :current_user, :params
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is related to #172

Basically, if your model lives inside a namespace that would not be considered when falling back when looking up for the policy.

With this change, if one had a controller `Api::V1::Foo::Bar` and a model `Foo::Bar`, when looking for the policy it would try `Api::V1::Foo::BarPolicy` and then `BarPolicy`. Now it will look for `Foo::BarPolicy`.
