### PR TITLE
Add 'pundit' prefix to instance variables to avoid collisions.

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -55,16 +55,16 @@ module Pundit
   end
 
   def verify_authorized
-    raise AuthorizationNotPerformedError unless @_policy_authorized
+    raise AuthorizationNotPerformedError unless @_pundit_policy_authorized
   end
 
   def verify_policy_scoped
-    raise PolicyScopingNotPerformedError unless @_policy_scoped
+    raise PolicyScopingNotPerformedError unless @_pundit_policy_scoped
   end
 
   def authorize(record, query=nil)
     query ||= params[:action].to_s + "?"
-    @_policy_authorized = true
+    @_pundit_policy_authorized = true
 
     policy = policy(record)
     unless policy.public_send(query)
@@ -78,7 +78,7 @@ module Pundit
   end
 
   def policy_scope(scope)
-    @_policy_scoped = true
+    @_pundit_policy_scoped = true
     policy_scopes[scope] ||= Pundit.policy_scope!(pundit_user, scope)
   end
 
@@ -87,11 +87,11 @@ module Pundit
   end
 
   def policies
-    @_policies ||= {}
+    @_pundit_policies ||= {}
   end
 
   def policy_scopes
-    @_policy_scopes ||= {}
+    @_pundit_policy_scopes ||= {}
   end
 
   def pundit_user


### PR DESCRIPTION
As reported in #198, this PR seeks to avoid naming collisions of instance variables by prefixing them with `pundit`.

_Note:_ The instance variable `@_policy` was mentioned in the above issue, but I wasn't able to find it's use in Pundit's codebase. Perhaps I'm missing something.
