### PR TITLE
Update rspec generator to case when rails_helper.rb exists

### DIFF
--- a/lib/generators/rspec/templates/policy_spec.rb
+++ b/lib/generators/rspec/templates/policy_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require '<%= File.exists?('spec/rails_helper.rb') ? 'rails_helper' : 'spec_helper' %>'
 
 describe <%= class_name %>Policy do
 


### PR DESCRIPTION
generator of rspec did not support existing rails_helper.rb from RSpec3, I coped.
