### PR TITLE
Use RSpec's described_class feature to specify the subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ create a special class which wraps up both user and IP and passes it to the poli
 ``` ruby
 class UserContext
   attr_reader :user, :ip
-  
+
   def initialize(user, ip)
     @user = user
     @ip = ip
@@ -439,7 +439,7 @@ end
 
 class ApplicationController
   include Pundit
-  
+
   def pundit_user
     UserContext.new(current_user, request.ip)
   end
@@ -501,7 +501,7 @@ Then put your policy specs in `spec/policies`, and make them look somewhat like 
 
 ``` ruby
 describe PostPolicy do
-  subject { PostPolicy }
+  subject { described_class }
 
   permissions :update? do
     it "denies access if post is published" do

--- a/lib/generators/rspec/templates/policy_spec.rb
+++ b/lib/generators/rspec/templates/policy_spec.rb
@@ -4,7 +4,7 @@ describe <%= class_name %>Policy do
 
   let(:user) { User.new }
 
-  subject { <%= class_name %>Policy }
+  subject { described_class }
 
   permissions ".scope" do
     pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/policies/post_policy_spec.rb
+++ b/spec/policies/post_policy_spec.rb
@@ -4,7 +4,7 @@ describe PostPolicy do
   let(:user) { double }
   let(:own_post) { double(user: user) }
   let(:other_post) { double(user: double) }
-  subject { PostPolicy }
+  subject { described_class }
 
   permissions :update?, :show? do
     it "is successful when all permissions match" do


### PR DESCRIPTION
Removes code duplication, making it easier to rename classes for example.
