### PR TITLE
Reorder policy spec actions in generator template

### DIFF
--- a/lib/generators/rspec/templates/policy_spec.rb
+++ b/lib/generators/rspec/templates/policy_spec.rb
@@ -10,11 +10,11 @@ describe <%= class_name %>Policy do
     pending "add some examples to (or delete) #{__FILE__}"
   end
 
-  permissions :create? do
+  permissions :show? do
     pending "add some examples to (or delete) #{__FILE__}"
   end
 
-  permissions :show? do
+  permissions :create? do
     pending "add some examples to (or delete) #{__FILE__}"
   end
 

--- a/lib/generators/test_unit/templates/policy_test.rb
+++ b/lib/generators/test_unit/templates/policy_test.rb
@@ -5,10 +5,10 @@ class <%= class_name %>PolicyTest < ActiveSupport::TestCase
   def test_scope
   end
 
-  def test_create
+  def test_show
   end
 
-  def test_show
+  def test_create
   end
 
   def test_update


### PR DESCRIPTION
These just seemed out of order. The default Rails controller generator as well as the generator for the ApplicationPolicy put them in this order.
