### PR TITLE
Replace `or` with `||` and `not` with `!` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ class PostPolicy
   end
 
   def update?
-    user.admin? or not post.published?
+    user.admin? || !post.published?
   end
 end
 ```
@@ -75,7 +75,7 @@ generator, or set up your own base class to inherit from:
 ``` ruby
 class PostPolicy < ApplicationPolicy
   def update?
-    user.admin? or not record.published?
+    user.admin? || !record.published?
   end
 end
 ```
@@ -203,7 +203,7 @@ class PostPolicy < ApplicationPolicy
   end
 
   def update?
-    user.admin? or not post.published?
+    user.admin? || !post.published?
   end
 end
 ```
@@ -236,7 +236,7 @@ class PostPolicy < ApplicationPolicy
   end
 
   def update?
-    user.admin? or not post.published?
+    user.admin? || !post.published?
   end
 end
 ```


### PR DESCRIPTION
All the popular ruby style guides ban the `or` keyword:

> The `and` and `or` keywords are banned. It's just not worth it. Always use
> `&&` and `||` instead.

https://github.com/styleguide/ruby
https://github.com/bbatsov/ruby-style-guide#no-and-or-or
https://github.com/airbnb/ruby#conditional-keywords

The same idea applies to `not`: It's for control flow, not boolean logic.
And like the others, its use here is misleading to programmers coming from
Python and Coffeescript.
