### PR TITLE
Update 18n sample in README to translate default translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,8 +366,7 @@ class ApplicationController < ActionController::Base
  def user_not_authorized(exception)
    policy_name = exception.policy.class.to_s.underscore
 
-   flash[:error] = I18n.t "pundit.#{policy_name}.#{exception.query}",
-     default: 'You cannot perform this action.'
+   flash[:error] = t "#{policy_name}.#{exception.query}", scope: "pundit", default: :default
    redirect_to(request.referrer || root_path)
  end
 end
@@ -376,6 +375,7 @@ end
 ```yaml
 en:
  pundit:
+   default: 'You cannot perform this action.'
    post_policy:
      update?: 'You cannot edit this post!'
      create?: 'You cannot create posts!'


### PR DESCRIPTION
Hi,

This small change just update 18n sample  to translate default value from 18n too.
This is done by using a scope and a default options as a symbol.
Also change to use `t`method in controller (available in latest rails versions) but this work with bare `I18n.t` too

Thanks for the great gem
