### PR TITLE
Update flash type in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ class ApplicationController < ActionController::Base
   private
 
   def user_not_authorized
-    flash[:error] = "You are not authorized to perform this action."
+    flash[:alert] = "You are not authorized to perform this action."
     redirect_to(request.referrer || root_path)
   end
 end


### PR DESCRIPTION
Out of box rails don't have :error flash type, only :alert and :notice
