### PR TITLE
Fix policy lookup for Rails 3 relations

### DIFF
--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -81,12 +81,7 @@ module Pundit
       elsif object.class.respond_to?(:policy_class)
         object.class.policy_class
       else
-        klass = if object.is_a?(Array)
-          object.map { |x| find_class_name(x) }.join("::")
-        else
-          find_class_name(object)
-        end
-        "#{klass}#{SUFFIX}"
+        "#{find_class_name(object)}#{SUFFIX}"
       end
     end
 
@@ -99,6 +94,8 @@ module Pundit
         subject
       elsif subject.is_a?(Symbol)
         subject.to_s.camelize
+      elsif subject.is_a?(Array)
+        subject.map { |x| find_class_name(x) }.join("::")
       else
         subject.class
       end

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -12,6 +12,7 @@ describe Pundit do
   let(:artificial_blog) { ArtificialBlog.new }
   let(:article_tag) { ArticleTag.new }
   let(:comments_relation) { CommentsRelation.new }
+  let(:rails_3_comments_relation) { Rails3CommentsRelation.new }
   let(:empty_comments_relation) { CommentsRelation.new(true) }
   let(:tag_four_five_six) { ProjectOneTwoThree::TagFourFiveSix.new(user) }
   let(:avatar_four_five_six) { ProjectOneTwoThree::AvatarFourFiveSix.new }
@@ -53,6 +54,10 @@ describe Pundit do
 
     it "returns an instantiated policy scope given an empty active record relation" do
       expect(Pundit.policy_scope(user, empty_comments_relation)).to eq empty_comments_relation
+    end
+
+    it "returns an instantiated policy scope given a Rails 3.x active record relation" do
+      expect(Pundit.policy_scope(user, rails_3_comments_relation)).to eq rails_3_comments_relation
     end
 
     it "returns nil if the given policy scope can't be found" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -109,6 +109,12 @@ class CommentsRelation
   end
 end
 
+class Rails3CommentsRelation < CommentsRelation
+  def is_a?(klass)
+    klass == Array
+  end
+end
+
 class Article; end
 
 class BlogPolicy < Struct.new(:user, :blog); end


### PR DESCRIPTION
Rails 3 relations look like Arrays (see: https://github.com/rails/rails/blob/v3.2.22.2/activerecord/lib/active_record/associations/collection_proxy.rb#L25), but can be identified by checking if they respond to #model_name.

Originally, when a policy class was being looked up, the object's `model_name` was tried first, then the lookup code checked if the object was an `Array`.  This order was swapped in 4f22dc1, which broke compatibility with Rails 3 relations by first checking if the object was an `Array`, which caused Rails 3 relations to be treated as an array of model instances.  For example, if a Foo has 3 Bars: `policy_scope(@foo.bars)` would try finding the `Bar::Bar::BarPolicy` instead of the `BarPolicy` as intended.

This commit restores the order of those two checks.  One small side-effect of this commit: Array lookups are now recursive, ex: `Pundit.policy(user, [[:foo, :bar], Post])` is now equivalent to `Pundit.policy(user, [:foo, :bar, Post])` and both will instantiate the FooBarPost policy.  I didn't write an explicit test for this as I can't think of a reasonable use-case for this behavior, but also don't believe it should break existing code as I can't imagine someone would prefer that the nested Array example instantiate the `ArrayPostPolicy` instead.

Thanks a bunch for this gem - authorization never felt right to me until I found Pundit.
