### PR TITLE
Allows additional methods to be used with Scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,45 @@ You can, and are encouraged to, use this method in views:
 <% end %>
 ```
 
+It is also possible to define additional methods the scope that you can use in
+different situations. We'll add an `unpublished` scope to the 
+`PostPolicy::Scope`:
+
+``` ruby
+class PostPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      if user.admin?
+        scope.all
+      else
+        scope.where(published: true)
+      end
+    end
+
+    def unpublished
+      if user.admin?
+        scope.all
+      else
+        scope.where(published: false)
+      end
+    end
+  end
+
+  def update?
+    user.admin? or not post.published?
+  end
+end
+```
+
+To use the `unpublished` scope, simply pass the name of the method as the 2nd 
+argument to `policy_scope`:
+
+``` ruby
+def index
+  @posts = policy_scope(Post, :unpublished)
+end
+```
+
 ## Ensuring policies and scopes are used
 
 When you are developing an application with Pundit it can be easy to forget to

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -43,6 +43,10 @@ describe Pundit do
       expect(Pundit.policy_scope(user, Post)).to eq :published
     end
 
+    it "returns an instantiated policy scope given the method to call on the scope" do
+      expect(Pundit.policy_scope(user, Post, :unpublished)).to eq :unpublished
+    end
+
     it "returns an instantiated policy scope given an active model class" do
       expect(Pundit.policy_scope(user, Comment)).to eq Comment
     end
@@ -67,6 +71,10 @@ describe Pundit do
   describe ".policy_scope!" do
     it "returns an instantiated policy scope given a plain model class" do
       expect(Pundit.policy_scope!(user, Post)).to eq :published
+    end
+
+    it "returns an instantiated policy scope given the method to call on the scope" do
+      expect(Pundit.policy_scope!(user, Post, :unpublished)).to eq :unpublished
     end
 
     it "returns an instantiated policy scope given an active model class" do
@@ -409,6 +417,10 @@ describe Pundit do
   describe "#policy_scope" do
     it "returns an instantiated policy scope" do
       expect(controller.policy_scope(Post)).to eq :published
+    end
+
+    it "returns an instantiated policy scope when a scope method is provided" do
+      expect(controller.policy_scope(Post, :unpublished)).to eq :unpublished
     end
 
     it "throws an exception if the given policy can't be found" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,10 @@ class PostPolicy < Struct.new(:user, :post)
     def resolve
       scope.published
     end
+
+    def unpublished
+      scope.unpublished
+    end
   end
 
   def update?
@@ -60,6 +64,10 @@ end
 class Post < Struct.new(:user)
   def self.published
     :published
+  end
+
+  def self.unpublished
+    :unpublished
   end
 
   def to_s


### PR DESCRIPTION
A proposal for issue #368.

Adds an additional argument to the `policy_scope` methods that specifies the method on the scope that should be called. Defaults to `:resolve` for backward compatibility.

This makes Scopes more flexible by allowing multiple scopes to be defined on a `Scope` class and making them available for use in controllers or views with existing helper methods.