### PR TITLE
Only rescue NameError related to wanted policy constants

### DIFF
--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -23,9 +23,7 @@ module Pundit
     #   scope.resolve #=> <#ActiveRecord::Relation ...>
     #
     def scope
-      policy::Scope if policy
-    rescue NameError
-      nil
+      "#{policy}::Scope".safe_constantize if policy
     end
 
     # @return [nil, Class] policy class with query methods
@@ -37,10 +35,11 @@ module Pundit
     #
     def policy
       klass = find
-      klass = klass.constantize if klass.is_a?(String)
-      klass
-    rescue NameError
-      nil
+      if klass.is_a?(String)
+        klass.safe_constantize
+      else
+        klass
+      end
     end
 
     # @return [Scope{#resolve}] scope class which can resolve to a scope

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -86,6 +86,14 @@ describe Pundit do
         Pundit.policy_scope!(user, nil)
       end.to raise_error(Pundit::NotDefinedError, "unable to find policy scope of nil")
     end
+
+    it "throws NameError if the policy is failed to be auto-loaded" do
+      expect(ArticleTagOtherNamePolicy).to receive(:const_missing).with(:Scope) do |_name|
+        AnotherMissingConstant
+      end
+      expect(Object).to receive(:const_missing).and_call_original
+      expect { Pundit.policy_scope!(user, ArticleTag) }.to raise_error(NameError)
+    end
   end
 
   describe ".policy" do
@@ -282,6 +290,14 @@ describe Pundit do
 
     it "throws an exception if the given policy is nil" do
       expect { Pundit.policy!(user, nil) }.to raise_error(Pundit::NotDefinedError, "unable to find policy of nil")
+    end
+
+    it "throws NameError if the policy has failed to be auto-loaded" do
+      expect(Object).to receive(:const_missing).with(:ArticlePolicy) do |_name|
+        AnotherMissingConstant
+      end
+      expect(Object).to receive(:const_missing).and_call_original
+      expect { Pundit.policy!(user, article) }.to raise_error(NameError)
     end
   end
 


### PR DESCRIPTION
Hello. When you are rescuing all `NameError`'s, you are also rescuing the errors not related to the constant you are trying to get - the ones that happen during autoload, for example. This will result in user getting wrong error messages:

```ruby
# autoloadable.rb
class AutoloadablePolicy < Missing
end
```
`Pundit.policy!(user, Autoloadable)` will throw ``Pundit::NotDefinedError: unable to find policy `AutoloadablePolicy` for `user` `` instead of `NameError: uninitialized constant Missing`.
Another example:
```ruby
# autoloadable.rb
class AutoloadablePolicy
  foo
end
```
`Pundit.policy!(user, Autoloadable)` will throw the same error instead of ``undefined local variable or method `foo' for main:Object``.
 This can confuse the gem user.