### PR TITLE
Fix code examples in Scopes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ class PostPolicy < ApplicationPolicy
   end
 
   def update?
-    user.admin? or not post.published?
+    user.admin? or not record.published?
   end
 end
 ```
@@ -254,7 +254,7 @@ class PostPolicy < ApplicationPolicy
   end
 
   def update?
-    user.admin? or not post.published?
+    user.admin? or not record.published?
   end
 end
 ```


### PR DESCRIPTION
Rename reference to `` post `` to `` record `` which would be currently correct one when PostPolicy class inherits ApplicationPolicy.