### PR TITLE
Error message when constructor called wrongly

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -82,6 +82,8 @@ module Pundit
     def policy_scope(user, scope)
       policy_scope = PolicyFinder.new(scope).scope
       policy_scope.new(user, scope).resolve if policy_scope
+    rescue ArgumentError
+      raise InvalidConstructorError, "Invalid #{policy_scope.class} constructor is called."
     end
 
     # Retrieves the policy scope for the given record.
@@ -92,7 +94,10 @@ module Pundit
     # @raise [NotDefinedError] if the policy scope cannot be found
     # @return [Scope{#resolve}] instance of scope class which can resolve to a scope
     def policy_scope!(user, scope)
-      PolicyFinder.new(scope).scope!.new(user, scope).resolve
+      policy_scope = PolicyFinder.new(scope).scope!
+      policy_scope.new(user, scope).resolve
+    rescue ArgumentError
+      raise InvalidConstructorError, "Invalid #{policy_scope.class} constructor is called."
     end
 
     # Retrieves the policy for the given record.
@@ -104,6 +109,8 @@ module Pundit
     def policy(user, record)
       policy = PolicyFinder.new(record).policy
       policy.new(user, record) if policy
+    rescue ArgumentError
+      raise InvalidConstructorError, "Invalid #{policy.class} constructor is called."
     end
 
     # Retrieves the policy for the given record.
@@ -114,7 +121,10 @@ module Pundit
     # @raise [NotDefinedError] if the policy cannot be found
     # @return [Object] instance of policy class with query methods
     def policy!(user, record)
-      PolicyFinder.new(record).policy!.new(user, record)
+      policy = PolicyFinder.new(record).policy!
+      policy.new(user, record)
+    rescue ArgumentError
+      raise InvalidConstructorError, "Invalid #{policy.class} constructor is called."
     end
   end
 

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -37,6 +37,9 @@ module Pundit
     end
   end
 
+  # Error that will be raised if a policy or policy scope constructor is not called correctly.
+  class InvalidConstructorError < Error; end
+
   # Error that will be raised if a controller action has not called the
   # `authorize` or `skip_authorization` methods.
   class AuthorizationNotPerformedError < Error; end

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -78,6 +78,7 @@ module Pundit
     # @see https://github.com/elabs/pundit#scopes
     # @param user [Object] the user that initiated the action
     # @param scope [Object] the object we're retrieving the policy scope for
+    # @raise [InvalidConstructorError] if the policy constructor called incorrectly
     # @return [Scope{#resolve}, nil] instance of scope class which can resolve to a scope
     def policy_scope(user, scope)
       policy_scope = PolicyFinder.new(scope).scope
@@ -92,6 +93,7 @@ module Pundit
     # @param user [Object] the user that initiated the action
     # @param scope [Object] the object we're retrieving the policy scope for
     # @raise [NotDefinedError] if the policy scope cannot be found
+    # @raise [InvalidConstructorError] if the policy constructor called incorrectly
     # @return [Scope{#resolve}] instance of scope class which can resolve to a scope
     def policy_scope!(user, scope)
       policy_scope = PolicyFinder.new(scope).scope!
@@ -105,6 +107,7 @@ module Pundit
     # @see https://github.com/elabs/pundit#policies
     # @param user [Object] the user that initiated the action
     # @param record [Object] the object we're retrieving the policy for
+    # @raise [InvalidConstructorError] if the policy constructor called incorrectly
     # @return [Object, nil] instance of policy class with query methods
     def policy(user, record)
       policy = PolicyFinder.new(record).policy
@@ -119,6 +122,7 @@ module Pundit
     # @param user [Object] the user that initiated the action
     # @param record [Object] the object we're retrieving the policy for
     # @raise [NotDefinedError] if the policy cannot be found
+    # @raise [InvalidConstructorError] if the policy constructor called incorrectly
     # @return [Object] instance of policy class with query methods
     def policy!(user, record)
       policy = PolicyFinder.new(record).policy!

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -84,7 +84,7 @@ module Pundit
       policy_scope = PolicyFinder.new(scope).scope
       policy_scope.new(user, scope).resolve if policy_scope
     rescue ArgumentError
-      raise InvalidConstructorError, "Invalid #{policy_scope.class} constructor is called."
+      raise InvalidConstructorError, "Invalid #<#{policy_scope}> constructor is called"
     end
 
     # Retrieves the policy scope for the given record.
@@ -99,7 +99,7 @@ module Pundit
       policy_scope = PolicyFinder.new(scope).scope!
       policy_scope.new(user, scope).resolve
     rescue ArgumentError
-      raise InvalidConstructorError, "Invalid #{policy_scope.class} constructor is called."
+      raise InvalidConstructorError, "Invalid #<#{policy_scope}> constructor is called"
     end
 
     # Retrieves the policy for the given record.
@@ -113,7 +113,7 @@ module Pundit
       policy = PolicyFinder.new(record).policy
       policy.new(user, record) if policy
     rescue ArgumentError
-      raise InvalidConstructorError, "Invalid #{policy.class} constructor is called."
+      raise InvalidConstructorError, "Invalid #<#{policy}> constructor is called"
     end
 
     # Retrieves the policy for the given record.
@@ -128,7 +128,7 @@ module Pundit
       policy = PolicyFinder.new(record).policy!
       policy.new(user, record)
     rescue ArgumentError
-      raise InvalidConstructorError, "Invalid #{policy.class} constructor is called."
+      raise InvalidConstructorError, "Invalid #<#{policy}> constructor is called"
     end
   end
 

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -15,6 +15,7 @@ describe Pundit do
   let(:empty_comments_relation) { CommentsRelation.new(true) }
   let(:tag_four_five_six) { ProjectOneTwoThree::TagFourFiveSix.new(user) }
   let(:avatar_four_five_six) { ProjectOneTwoThree::AvatarFourFiveSix.new }
+  let(:wiki) { Wiki.new }
 
   describe ".authorize" do
     it "infers the policy and authorizes based on it" do
@@ -35,6 +36,12 @@ describe Pundit do
         expect(error.record).to eq post
         expect(error.policy).to eq Pundit.policy(user, post)
       end
+    end
+
+    it "raises an error with a invalid policy constructor" do
+      expect do
+        Pundit.authorize(user, wiki, :update?)
+      end.to raise_error(Pundit::InvalidConstructorError, "Invalid #<WikiPolicy> constructor is called")
     end
   end
 
@@ -62,6 +69,12 @@ describe Pundit do
     it "returns nil if blank object given" do
       expect(Pundit.policy_scope(user, nil)).to be_nil
     end
+
+    it "raises an error with a invalid policy scope constructor" do
+      expect do
+        Pundit.policy_scope(user, Wiki)
+      end.to raise_error(Pundit::InvalidConstructorError, "Invalid #<WikiPolicy::Scope> constructor is called")
+    end
   end
 
   describe ".policy_scope!" do
@@ -85,6 +98,12 @@ describe Pundit do
       expect do
         Pundit.policy_scope!(user, nil)
       end.to raise_error(Pundit::NotDefinedError, "unable to find policy scope of nil")
+    end
+
+    it "raises an error with a invalid policy scope constructor" do
+      expect do
+        Pundit.policy_scope(user, Wiki)
+      end.to raise_error(Pundit::InvalidConstructorError, "Invalid #<WikiPolicy::Scope> constructor is called")
     end
   end
 
@@ -146,6 +165,12 @@ describe Pundit do
       expect(policy.class).to eq Project::PostPolicy
       expect(policy.user).to eq user
       expect(policy.post).to eq [:project, Post]
+    end
+
+    it "raises an error with a invalid policy constructor" do
+      expect do
+        Pundit.policy(user, Wiki)
+      end.to raise_error(Pundit::InvalidConstructorError, "Invalid #<WikiPolicy> constructor is called")
     end
 
     it "returns an instantiated policy given an array of a symbol and an active model class" do
@@ -283,6 +308,12 @@ describe Pundit do
     it "throws an exception if the given policy is nil" do
       expect { Pundit.policy!(user, nil) }.to raise_error(Pundit::NotDefinedError, "unable to find policy of nil")
     end
+
+    it "raises an error with a invalid policy constructor" do
+      expect do
+        Pundit.policy(user, Wiki)
+      end.to raise_error(Pundit::InvalidConstructorError, "Invalid #<WikiPolicy> constructor is called")
+    end
   end
 
   describe "#verify_authorized" do
@@ -365,6 +396,10 @@ describe Pundit do
     it "raises an error when the given record is nil" do
       expect { controller.authorize(nil, :destroy?) }.to raise_error(Pundit::NotDefinedError)
     end
+
+    it "raises an error with a invalid policy constructor" do
+      expect { controller.authorize(wiki, :destroy?) }.to raise_error(Pundit::InvalidConstructorError)
+    end
   end
 
   describe "#skip_authorization" do
@@ -398,6 +433,10 @@ describe Pundit do
       expect { controller.policy(article) }.to raise_error(Pundit::NotDefinedError)
     end
 
+    it "raises an error with a invalid policy constructor" do
+      expect { controller.policy(wiki) }.to raise_error(Pundit::InvalidConstructorError)
+    end
+
     it "allows policy to be injected" do
       new_policy = OpenStruct.new
       controller.policies[post] = new_policy
@@ -413,6 +452,10 @@ describe Pundit do
 
     it "throws an exception if the given policy can't be found" do
       expect { controller.policy_scope(Article) }.to raise_error(Pundit::NotDefinedError)
+    end
+
+    it "raises an error with a invalid policy scope constructor" do
+      expect { controller.policy_scope(Wiki) }.to raise_error(Pundit::InvalidConstructorError)
     end
 
     it "allows policy_scope to be injected" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -176,6 +176,14 @@ class NilClassPolicy
   end
 end
 
+class Wiki; end
+class WikiPolicy
+  class Scope
+    # deliberate typo method
+    def initalize; end
+  end
+end
+
 class PostFourFiveSix < Struct.new(:user); end
 
 class CommentFourFiveSix; extend ActiveModel::Naming; end


### PR DESCRIPTION
**Description**
Currently, Pundit just raises an ArgumentError when policy constructor called incorrectly. This might not be too easy to understand since the error originates deep inside Pundit. So this feature aims to provide clear error messages.

Attempt to fix issue https://github.com/elabs/pundit/issues/448

**TODO**
- [x] Define specific error type
- [x] Raise the error in Pundit core functions
- [x] Documentation
- [x] Test coverage