### PR TITLE
fix PolicyFinder when given an array with policy class override

### DIFF
--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -134,6 +134,13 @@ describe Pundit do
       expect(policy.post).to eq [:project, post]
     end
 
+    it "returns an instantiated policy given an array of a symbol and a model instance with policy_class override" do
+      policy = Pundit.policy(user, [:project, customer_post])
+      expect(policy.class).to eq Project::PostPolicy
+      expect(policy.user).to eq user
+      expect(policy.post).to eq [:project, customer_post]
+    end
+
     it "returns an instantiated policy given an array of a symbol and an active model instance" do
       policy = Pundit.policy(user, [:project, comment])
       expect(policy.class).to eq Project::CommentPolicy
@@ -153,6 +160,13 @@ describe Pundit do
       expect(policy.class).to eq Project::CommentPolicy
       expect(policy.user).to eq user
       expect(policy.post).to eq [:project, Comment]
+    end
+
+    it "returns an instantiated policy given an array of a symbol and a class with policy_class override" do
+      policy = Pundit.policy(user, [:project, Customer::Post])
+      expect(policy.class).to eq Project::PostPolicy
+      expect(policy.user).to eq user
+      expect(policy.post).to eq [:project, Customer::Post]
     end
 
     it "returns correct policy class for an array of a multi-word symbols" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,8 +77,12 @@ module Customer
       OpenStruct.new(param_key: "customer_post")
     end
 
-    def policy_class
+    def self.policy_class
       PostPolicy
+    end
+
+    def policy_class
+      self.class.policy_class
     end
   end
 end


### PR DESCRIPTION
When trying to find a policy using an array, the `policy_class` override method was not getting called on the last item of the array.