### PR TITLE
Resolves the correct scope for namespaced scopes 

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -2,6 +2,7 @@
 
 require "pundit/version"
 require "pundit/policy_finder"
+require "pundit/scope_resolver"
 require "active_support/concern"
 require "active_support/core_ext/string/inflections"
 require "active_support/core_ext/object/blank"

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -77,8 +77,7 @@ module Pundit
     # @param scope [Object] the object we're retrieving the policy scope for
     # @return [Scope{#resolve}, nil] instance of scope class which can resolve to a scope
     def policy_scope(user, scope)
-      policy_scope = PolicyFinder.new(scope).scope
-      policy_scope.new(user, scope).resolve if policy_scope
+      ScopeResolver.new(user, scope).resolve
     end
 
     # Retrieves the policy scope for the given record.
@@ -89,7 +88,7 @@ module Pundit
     # @raise [NotDefinedError] if the policy scope cannot be found
     # @return [Scope{#resolve}] instance of scope class which can resolve to a scope
     def policy_scope!(user, scope)
-      PolicyFinder.new(scope).scope!.new(user, scope).resolve
+      ScopeResolver.new(user, scope).resolve!
     end
 
     # Retrieves the policy for the given record.

--- a/lib/pundit/scope_resolver.rb
+++ b/lib/pundit/scope_resolver.rb
@@ -1,0 +1,49 @@
+module Pundit
+  # Finds policy scope class for given object.
+  # @api public
+  # @example
+  #   user = User.find(params[:id])
+  #   resolver = PolicyResolver.new(user, Post)
+  #   resolver.resolve #=> calls PostPolicy::Scope.new(user, Post).resolve
+  #
+  #   resolver = PolicyResolver.new(user, [:admin, Post])
+  #   resolver.resolve #=> calls Admin::PostPolicy::Scope.new(user, Post).resolve
+  #
+  class ScopeResolver
+    #
+    # @param resource_scope [any] the object to find policy and scope classes for
+    #     could be a class name like `Post` or an array
+    #     to define a namespaced class like `[:admin, Post]`
+    # @param user [object] pundit current user
+    #
+    def initialize(user, resource_scope)
+      @user = user
+      @resource_scope = resource_scope.respond_to?(:each) ? resource_scope.last : resource_scope
+      @policy_class = PolicyFinder.new(resource_scope).policy
+    end
+
+    # @return [object] the return value of Policy::Scope#resolve
+    #
+    def resolve
+      scope_class.new(@user, @resource_scope).resolve if scope_class
+    end
+
+    # @return [object] the return value of Policy::Scope#resolve
+    # @raise [NotDefinedError] if policy scope could not be determined
+    #
+    def resolve!
+      scope_class!.new(@user, @resource_scope).resolve
+    end
+
+    private
+
+    def scope_class
+      "#{@policy_class}::Scope".safe_constantize
+    end
+
+    def scope_class!
+      raise NotDefinedError, "unable to find policy scope of nil" if @resource_scope.nil?
+      scope_class or raise NotDefinedError, "unable to find Scope class for `#{@policy_class}`"
+    end
+  end
+end

--- a/pundit.gemspec
+++ b/pundit.gemspec
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "pundit/version"

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -421,6 +421,15 @@ describe Pundit do
 
       expect(controller.policy_scope(Post)).to eq new_scope
     end
+
+    it "raises an error if a namespace policy scope cannot be found" do
+      expect { controller.policy_scope([:project, Comment]) }.to raise_error(Pundit::NotDefinedError)
+    end
+
+    it "resolves a policy scope under admin namespace" do
+      scope = controller.policy_scope([:admin, Post])
+      expect(scope).to eq Post.published
+    end
   end
 
   describe "#permitted_attributes" do

--- a/spec/scope_resolver_spec.rb
+++ b/spec/scope_resolver_spec.rb
@@ -1,0 +1,80 @@
+require "spec_helper"
+
+module Pundit
+  describe ScopeResolver do
+    subject { described_class.new(user, resource_scope) }
+    let(:user) { double('pundit_user') }
+
+    describe '#resolve' do
+      context 'policy class cannot be found' do
+        let(:resource_scope) { nil }
+
+        it { expect(subject.resolve).to be nil }
+      end
+
+      context 'policy class with not a defined Scope class' do
+        let(:resource_scope) { None }
+
+        before {
+          expect("#{resource_scope}Policy".safe_constantize).to be_present
+          expect("#{resource_scope}Policy::Scope".safe_constantize).to_not be_present
+        }
+
+        it { expect(subject.resolve).to be nil }
+      end
+
+      context 'policy class with a defined Scope class' do
+        let(:resource_scope) { Post }
+
+        before {
+          expect("#{resource_scope}Policy".safe_constantize).to be_present
+          expect("#{resource_scope}Policy::Scope".safe_constantize).to be_present
+        }
+
+        it { expect(subject.resolve).to eq :published }
+      end
+
+      context 'namespaced resource scope' do
+        let(:resource_scope) { [:admin, Post] }
+
+        it { expect(subject.resolve).to eq :published }
+      end
+    end
+
+    describe '#resolve!' do
+      context 'policy class cannot be found' do
+        let(:resource_scope) { nil }
+
+        it { expect{subject.resolve!}.to raise_error(Pundit::NotDefinedError, /unable to find policy scope of nil/) }
+      end
+
+      context 'policy class with not a defined Scope class' do
+        let(:resource_scope) { None }
+
+        before {
+          expect("#{resource_scope}Policy".safe_constantize).to be_present
+          expect("#{resource_scope}Policy::Scope".safe_constantize).to_not be_present
+        }
+
+        it { expect{subject.resolve!}.to raise_error(Pundit::NotDefinedError, /unable to find Scope class for `#{resource_scope}Policy`/) }
+      end
+
+      context 'policy class with a defined Scope class' do
+        let(:resource_scope) { Post }
+
+        before {
+          expect("#{resource_scope}Policy".safe_constantize).to be_present
+          expect("#{resource_scope}Policy::Scope".safe_constantize).to be_present
+        }
+
+        it { expect(subject.resolve!).to eq :published }
+      end
+
+      context 'namespaced resource scope' do
+        let(:resource_scope) { [:admin, Post] }
+
+        it { expect(subject.resolve!).to eq :published }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,12 @@ RSpec.configure do |config|
   config.include PunditSpecHelper
 end
 
+class NonePolicy
+end
+
+class None
+end
+
 class PostPolicy < Struct.new(:user, :post)
   class Scope < Struct.new(:user, :scope)
     def resolve

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -180,6 +180,16 @@ class PostFourFiveSix < Struct.new(:user); end
 
 class CommentFourFiveSix; extend ActiveModel::Naming; end
 
+module Admin
+  class PostPolicy < Struct.new(:user, :post)
+    class Scope < Struct.new(:user, :scope)
+      def resolve
+        scope.published
+      end
+    end
+  end
+end
+
 module ProjectOneTwoThree
   class CommentFourFiveSixPolicy < Struct.new(:user, :post); end
 


### PR DESCRIPTION
What I was trying to do is addressed here #482. The documentation for namespace support is addressed here #392. In summary a bug exist when we call `policy_scope` for a namespace resource.

Previously when we called `scope_policy([:admin, Post])`, the correct `Admin::PostPolicy::Scope` class is found but `scope` in `Admin::PostPolicy::Scope{@scope = [:admin, Post]}` holds the passed in array instead of `Post` class. 

This PR fixes the above issue to take into account the last argument of the passed in array as the scope if the passed in object responds to `:each`.

