### PR TITLE
Use `.all` in generated policy scopes

### DIFF
--- a/lib/generators/pundit/install/templates/application_policy.rb
+++ b/lib/generators/pundit/install/templates/application_policy.rb
@@ -43,7 +43,7 @@ class ApplicationPolicy
     end
 
     def resolve
-      scope
+      scope.all
     end
   end
 end

--- a/lib/generators/pundit/policy/templates/policy.rb
+++ b/lib/generators/pundit/policy/templates/policy.rb
@@ -2,7 +2,7 @@
 class <%= class_name %>Policy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope
+      scope.all
     end
   end
 end

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -52,15 +52,15 @@ describe Pundit do
     end
 
     it "returns an instantiated policy scope given an active model class" do
-      expect(Pundit.policy_scope(user, Comment)).to eq Comment
+      expect(Pundit.policy_scope(user, Comment)).to eq CommentScope.new(Comment)
     end
 
     it "returns an instantiated policy scope given an active record relation" do
-      expect(Pundit.policy_scope(user, comments_relation)).to eq comments_relation
+      expect(Pundit.policy_scope(user, comments_relation)).to eq CommentScope.new(comments_relation)
     end
 
     it "returns an instantiated policy scope given an empty active record relation" do
-      expect(Pundit.policy_scope(user, empty_comments_relation)).to eq empty_comments_relation
+      expect(Pundit.policy_scope(user, empty_comments_relation)).to eq CommentScope.new(empty_comments_relation)
     end
 
     it "returns nil if the given policy scope can't be found" do
@@ -84,7 +84,7 @@ describe Pundit do
     end
 
     it "returns an instantiated policy scope given an active model class" do
-      expect(Pundit.policy_scope!(user, Comment)).to eq Comment
+      expect(Pundit.policy_scope!(user, Comment)).to eq CommentScope.new(Comment)
     end
 
     it "throws an exception if the given policy scope can't be found" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -87,10 +87,21 @@ module Customer
   end
 end
 
+class CommentScope
+  attr_reader :original_object
+  def initialize(original_object)
+    @original_object = original_object
+  end
+
+  def ==(other)
+    original_object == other.original_object
+  end
+end
+
 class CommentPolicy < Struct.new(:user, :comment)
   class Scope < Struct.new(:user, :scope)
     def resolve
-      scope
+      CommentScope.new(scope)
     end
   end
 end


### PR DESCRIPTION
The current generated policy scopes return the `scope` object directly. This can cause some weird inconsistent behavior, since this means that `policy_scope(MyKlass.scope_or_relation)` will return a relation-like object, while `policy_scope(MyKlass)` will return a class, which is not a relation and does not respond appropriately to things like `my_policy_scope.to_a` or `MyKlass.where(xyz).merge(my_policy_scope)`.

I think, and the examples in the README agree, that for at least everyone using ActiveRecord the best default is to return `scope.all`. This patch updates the generated policies to use that default. I also updated a spec helper that was using the same pattern—not crucial, but it avoids misleading people and I think I improved the specs at the same time.