### PR TITLE
Add PolicyFinder spec and refactor to avoid rescues

### DIFF
--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -23,9 +23,7 @@ module Pundit
     #   scope.resolve #=> <#ActiveRecord::Relation ...>
     #
     def scope
-      policy::Scope if policy
-    rescue NameError
-      nil
+      "#{policy}::Scope".safe_constantize
     end
 
     # @return [nil, Class] policy class with query methods
@@ -37,10 +35,7 @@ module Pundit
     #
     def policy
       klass = find(object)
-      klass = klass.constantize if klass.is_a?(String)
-      klass
-    rescue NameError
-      nil
+      klass.is_a?(String) ? klass.safe_constantize : klass
     end
 
     # @return [Scope{#resolve}] scope class which can resolve to a scope

--- a/spec/policy_finder_spec.rb
+++ b/spec/policy_finder_spec.rb
@@ -1,0 +1,110 @@
+require "spec_helper"
+
+describe Pundit::PolicyFinder do
+  let(:user) { double }
+  let(:post) { Post.new(user) }
+  let(:comment) { CommentFourFiveSix.new }
+  let(:article) { Article.new }
+
+  describe "#scope" do
+    subject { described_class.new(post) }
+
+    it "returns a policy scope" do
+      expect(subject.scope).to eq PostPolicy::Scope
+    end
+
+    context "policy is nil" do
+      it "returns nil" do
+        allow(subject).to receive(:policy).and_return nil
+        expect(subject.scope).to eq nil
+      end
+    end
+  end
+
+  describe "#policy" do
+    subject { described_class.new(post) }
+
+    it "returns a policy" do
+      expect(subject.policy).to eq PostPolicy
+    end
+
+    context "with a string" do
+      it "returns a policy" do
+        allow(subject).to receive(:find).and_return "PostPolicy"
+        expect(subject.policy).to eq PostPolicy
+      end
+    end
+
+    context "with a class" do
+      it "returns a policy" do
+        allow(subject).to receive(:find).and_return PostPolicy
+        expect(subject.policy).to eq PostPolicy
+      end
+    end
+
+    context "with nil" do
+      it "returns nil" do
+        allow(subject).to receive(:find).and_return nil
+        expect(subject.policy).to eq nil
+      end
+    end
+
+    context "with a string that can't be constantized" do
+      it "returns nil" do
+        allow(subject).to receive(:find).and_return "FooPolicy"
+        expect(subject.policy).to eq nil
+      end
+    end
+  end
+
+  describe "#scope!" do
+    context "@object is nil" do
+      subject { described_class.new(nil) }
+
+      it "returns a NotDefinedError" do
+        expect { subject.scope! }.to raise_error Pundit::NotDefinedError
+      end
+    end
+
+    context "@object is defined" do
+      subject { described_class.new(post) }
+
+      it "returns the scope" do
+        expect(subject.scope!).to eq PostPolicy::Scope
+      end
+    end
+  end
+
+  describe "#param_key" do
+    context "object responds to model_name" do
+      subject { described_class.new(comment) }
+
+      it "returns the param_key" do
+        expect(subject.object).to respond_to(:model_name)
+        expect(subject.param_key).to eq "comment_four_five_six"
+      end
+    end
+
+    context "object is a class" do
+      subject { described_class.new(Article) }
+
+      it "returns the param_key" do
+        expect(subject.object).not_to respond_to(:model_name)
+        expect(subject.object).to be_a Class
+        expect(subject.param_key).to eq "article"
+      end
+    end
+
+    context "object is an instance of a class" do
+      subject { described_class.new(article) }
+
+      it "returns the param_key" do
+        expect(subject.object).not_to respond_to(:model_name)
+        expect(subject.object).not_to be_a Class
+        expect(subject.object).to be_an_instance_of Article
+
+        expect(subject.param_key).to eq "article"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Small refactor of `PolicyFinder` to use ActiveSupport's [`safe_constantize`](https://apidock.com/rails/ActiveSupport/Inflector/safe_constantize) method instead of having to rescue `NameError`.

Also adds a `policy_finder_spec` for unit tests of the `PolicyFinder` class. 

I'm not sure how you all feel about stylistic refactors 🤷‍♂️ . If you're not a fan, I can remove the second commit here. I think the tests add value, though.