### PR TITLE
Pin RuboCop version to 0.51.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ group :development, :test do
   gem "pry"
   gem "rake"
   gem "rspec"
-  gem "rubocop"
+  gem "rubocop", "0.51.0"
   gem "yard"
 end


### PR DESCRIPTION
Build is failing due to update of RuboCop now.
I think pinning RuboCop version is friendly to contributors.