### PR TITLE
Travis: jruby-9.2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ matrix:
     - rvm: 2.3.5
     - rvm: 2.4.2
     - rvm: 2.5.1
-    - rvm: jruby-9.1.8.0
+    - rvm: jruby-9.2.0.0
       env:
         - JRUBY_OPTS="--debug"


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2018/05/24/jruby-9-2-0-0.html