### PR TITLE
Improve model policy template convenience

### DIFF
--- a/lib/generators/pundit/policy/templates/policy.rb
+++ b/lib/generators/pundit/policy/templates/policy.rb
@@ -1,5 +1,25 @@
 <% module_namespacing do -%>
 class <%= class_name %>Policy < ApplicationPolicy
+  def index?
+    super
+  end
+
+  def create?
+    super
+  end
+
+  def update?
+    super
+  end
+
+  def delete?
+    super
+  end
+
+  def permitted_attributes
+    %i[]
+  end
+
   class Scope < Scope
     def resolve
       scope.all


### PR DESCRIPTION
With an ApplicationPolicy set up to deny all, the first step to take after generating a model policy is to override ApplicationPolicy methods.  This patch adds stub methods to the model policy template to make that step more convenient.  The `new?` and `edit?` methods are excluded because the default ApplicationPolicy already defers their behavior to `create?` and `update?`, respectively.