### PR TITLE
Allow specification of a NilClassPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,27 @@ class ApplicationPolicy
 end
 ```
 
+## NilClassPolicy
+
+To support a [null object pattern](https://en.wikipedia.org/wiki/Null_Object_pattern)
+you may find that you want to implement a `NilClassPolicy`. This might be useful
+where you want to extend your ApplicationPolicy to allow some tolerance of, for
+example, associations which might be `nil`.
+
+```ruby
+class NilClassPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      raise Pundit::NotDefinedError, "Cannot scope NilClass"
+    end
+  end
+
+  def show?
+    false # Nobody can see nothing
+  end
+end
+```
+
 ## Rescuing a denied Authorization in Rails
 
 Pundit raises a `Pundit::NotAuthorizedError` you can

--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -42,7 +42,6 @@ module Pundit
     # @raise [NotDefinedError] if scope could not be determined
     #
     def scope!
-      raise NotDefinedError, "unable to find policy scope of nil" if object.nil?
       scope or raise NotDefinedError, "unable to find scope `#{find(object)}::Scope` for `#{object.inspect}`"
     end
 
@@ -50,7 +49,6 @@ module Pundit
     # @raise [NotDefinedError] if policy could not be determined
     #
     def policy!
-      raise NotDefinedError, "unable to find policy of nil" if object.nil?
       policy or raise NotDefinedError, "unable to find policy `#{find(object)}` for `#{object.inspect}`"
     end
 
@@ -69,9 +67,7 @@ module Pundit
   private
 
     def find(subject)
-      if subject.nil?
-        nil
-      elsif subject.is_a?(Array)
+      if subject.is_a?(Array)
         modules = subject.dup
         last = modules.pop
         context = modules.map { |x| find_class_name(x) }.join("::")

--- a/spec/policy_finder_spec.rb
+++ b/spec/policy_finder_spec.rb
@@ -61,8 +61,8 @@ describe Pundit::PolicyFinder do
     context "@object is nil" do
       subject { described_class.new(nil) }
 
-      it "returns a NotDefinedError" do
-        expect { subject.scope! }.to raise_error Pundit::NotDefinedError
+      it "returns the NilClass policy's scope class" do
+        expect(subject.scope!).to eq NilClassPolicy::Scope
       end
     end
 

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -67,8 +67,8 @@ describe Pundit do
       expect(Pundit.policy_scope(user, Article)).to be_nil
     end
 
-    it "returns nil if blank object given" do
-      expect(Pundit.policy_scope(user, nil)).to be_nil
+    it "raises an exception if nil object given" do
+      expect { Pundit.policy_scope(user, nil) }.to raise_error(Pundit::NotDefinedError)
     end
 
     it "raises an error with a invalid policy scope constructor" do
@@ -98,7 +98,7 @@ describe Pundit do
     it "throws an exception if the given policy scope is nil" do
       expect do
         Pundit.policy_scope!(user, nil)
-      end.to raise_error(Pundit::NotDefinedError, "unable to find policy scope of nil")
+      end.to raise_error(Pundit::NotDefinedError, "Cannot scope NilClass")
     end
 
     it "raises an error with a invalid policy scope constructor" do
@@ -245,8 +245,8 @@ describe Pundit do
       expect(Pundit.policy(user, Article)).to be_nil
     end
 
-    it "returns nil if the given policy is nil" do
-      expect(Pundit.policy(user, nil)).to be_nil
+    it "returns the specified NilClassPolicy for nil" do
+      expect(Pundit.policy(user, nil)).to be_a NilClassPolicy
     end
 
     describe "with .policy_class set on the model" do
@@ -320,8 +320,8 @@ describe Pundit do
       expect { Pundit.policy!(user, Article) }.to raise_error(Pundit::NotDefinedError)
     end
 
-    it "throws an exception if the given policy is nil" do
-      expect { Pundit.policy!(user, nil) }.to raise_error(Pundit::NotDefinedError, "unable to find policy of nil")
+    it "returns the specified NilClassPolicy for nil" do
+      expect(Pundit.policy!(user, nil)).to be_a NilClassPolicy
     end
 
     it "raises an error with a invalid policy constructor" do
@@ -409,7 +409,7 @@ describe Pundit do
     end
 
     it "raises an error when the given record is nil" do
-      expect { controller.authorize(nil, :destroy?) }.to raise_error(Pundit::NotDefinedError)
+      expect { controller.authorize(nil, :destroy?) }.to raise_error(Pundit::NotAuthorizedError)
     end
 
     it "raises an error with a invalid policy constructor" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -182,15 +182,19 @@ class Controller
   end
 end
 
-class NilClassPolicy
+class NilClassPolicy < Struct.new(:user, :record)
   class Scope
     def initialize(*)
-      raise "I'm only here to be annoying!"
+      raise Pundit::NotDefinedError, "Cannot scope NilClass"
     end
   end
 
-  def initialize(*)
-    raise "I'm only here to be annoying!"
+  def show?
+    false
+  end
+
+  def destroy?
+    false
   end
 end
 


### PR DESCRIPTION
This saves having to check whether objects are nil before checking their
policy.

This contradicts the intent of elabs/pundit#251 and could represent a
breaking change for some.

@Linuus a couple of our projects are using the branch I created the original PR from, so I'm opening this rebased as a separate PR.