### PR TITLE
feat(PolicyScope): Add ability to override the policy scope class

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,13 @@ Pundit.policy_scope(user, Post)
 The bang methods will raise an exception if the policy does not exist, whereas
 those without the bang will return nil.
 
+Similar to the `policy_scope` instance method, you can also override the policy scope class:
+
+``` ruby
+Pundit.policy_scope!(user, Post, policy_scope_class: PublicationPolicy::Scope)
+Pundit.policy_scope(user, Post, policy_scope_class: PublicationPolicy::Scope)
+```
+
 ## Customize Pundit user
 
 In some cases your controller might not have access to `current_user`, or your

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -79,7 +79,9 @@ module Pundit
     # @param scope [Object] the object we're retrieving the policy scope for
     # @raise [InvalidConstructorError] if the policy constructor called incorrectly
     # @return [Scope{#resolve}, nil] instance of scope class which can resolve to a scope
-    def policy_scope(user, scope)
+    def policy_scope(user, scope, policy_scope_class: nil)
+      return policy_scope_class.new(user, scope).resolve if policy_scope_class
+
       policy_scope = PolicyFinder.new(scope).scope
       policy_scope.new(user, pundit_model(scope)).resolve if policy_scope
     rescue ArgumentError
@@ -94,7 +96,9 @@ module Pundit
     # @raise [NotDefinedError] if the policy scope cannot be found
     # @raise [InvalidConstructorError] if the policy constructor called incorrectly
     # @return [Scope{#resolve}] instance of scope class which can resolve to a scope
-    def policy_scope!(user, scope)
+    def policy_scope!(user, scope, policy_scope_class: nil)
+      return policy_scope_class.new(user, scope).resolve if policy_scope_class
+
       policy_scope = PolicyFinder.new(scope).scope!
       policy_scope.new(user, pundit_model(scope)).resolve
     rescue ArgumentError

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -79,6 +79,10 @@ describe Pundit do
       expect(Pundit.policy_scope(user, Article)).to be_nil
     end
 
+    it "allows policy scope class to be overriden" do
+      expect(Pundit.policy_scope(user, Post, policy_scope_class: PublicationPolicy::Scope)).to eq :published
+    end
+
     it "raises an exception if nil object given" do
       expect { Pundit.policy_scope(user, nil) }.to raise_error(Pundit::NotDefinedError)
     end
@@ -97,6 +101,10 @@ describe Pundit do
 
     it "returns an instantiated policy scope given an active model class" do
       expect(Pundit.policy_scope!(user, Comment)).to eq CommentScope.new(Comment)
+    end
+
+    it "allows policy scope class to be overriden" do
+      expect(Pundit.policy_scope!(user, Post, policy_scope_class: PublicationPolicy::Scope)).to eq :published
     end
 
     it "throws an exception if the given policy scope can't be found" do


### PR DESCRIPTION
There was a new feature added to the instance method `policy_scope`
that allowed the policy scope class to be manually declared via the
`policy_scope_class` argument. This adds that same functionality to
the class method.

Closes #537 