### PR TITLE
Update Readme to make possible use of `policy_class` in admin namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,8 +582,8 @@ class AdminController < ApplicationController
     super([:admin, scope])
   end
 
-  def authorize(record, query = nil)
-    super([:admin, record], query)
+  def authorize(record, query = nil, options = {})
+    super([:admin, record], query, options)
   end
 end
 


### PR DESCRIPTION
A little correction. In 2.0 I had to add this to be able to specify `policy_class` in my admin controllers.