### PR TITLE
Policy cache will depend on user also

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -244,7 +244,7 @@ protected
   # @param record [Object] the object we're retrieving the policy for
   # @return [Object, nil] instance of policy class with query methods
   def policy(record)
-    policies[record] ||= Pundit.policy!(pundit_user, record)
+    policies[[pundit_user, record]] ||= Pundit.policy!(pundit_user, record)
   end
 
   # Retrieves a set of permitted attributes from the policy by instantiating

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -427,9 +427,9 @@ describe Pundit do
     end
 
     it "caches the policy" do
-      expect(controller.policies[post]).to be_nil
+      expect(controller.policies[[user, post]]).to be_nil
       controller.authorize(post)
-      expect(controller.policies[post]).not_to be_nil
+      expect(controller.policies[[user, post]]).not_to be_nil
     end
 
     it "raises an error when the given record is nil" do
@@ -478,7 +478,7 @@ describe Pundit do
 
     it "allows policy to be injected" do
       new_policy = OpenStruct.new
-      controller.policies[post] = new_policy
+      controller.policies[[user, post]] = new_policy
 
       expect(controller.policy(post)).to eq new_policy
     end


### PR DESCRIPTION
I have two namespaces with different `pundit_user`.

I noticed that when I do something in admin namespace, then I visit the site (as guest) and come back to admin, sometimes randomly (very hard to reproduce) I get `nil` instead of `user`, which is defined, otherwise devise would redirect me to login page. Much worse it would be if I was logged as admin and as user at the same time, instead of `nil` I would get authorizations against a wrong user!

Error goes away if I restart rails server or change some code to trigger a code reload (in development). I added a `Rails.logger.debug` to my base policy initializers and noticed that policy initializer is not called but I see a SQL query loading the user before, so it is a cache problem. The record may be the same but user is different.

So I added the user as second key, now it works correctly.