### PR TITLE
Add Suffix Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,33 @@ class Admin::PostController < AdminController
 end
 ```
 
+## Configuring Custom Policy Names
+
+In very rare occassions the `Policy` suffix may not work well in your
+application domain. To resolve this issue, Pundit allows you to
+configure a different suffix for your application policies so that the
+policy lookup well infer policy names using that suffix rather than
+`Policy`.
+
+```ruby
+Pundit.configure do |config|
+  config.suffix = "Authorization"
+end
+
+class PolicyAuthorization < ApplicationAuthorization
+  def show?
+    user.admin?
+  end
+end
+
+class Admin::PolicyController < AdminController
+  def show
+    policy = Policy.find(params[:id])
+    authorize(policy)
+  end
+end
+```
+
 ## Additional context
 
 Pundit strongly encourages you to model your application in such a way that the

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "pundit/version"
+require "pundit/configuration"
 require "pundit/policy_finder"
 require "active_support/concern"
 require "active_support/core_ext/string/inflections"
@@ -10,8 +11,6 @@ require "active_support/dependencies/autoload"
 
 # @api public
 module Pundit
-  SUFFIX = "Policy".freeze
-
   # @api private
   module Generators; end
 
@@ -54,6 +53,14 @@ module Pundit
   extend ActiveSupport::Concern
 
   class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configure
+      yield(configuration)
+    end
+
     # Retrieves the policy for the given record, initializing it with the
     # record and user and finally throwing an error if the user is not
     # authorized to perform the given action.

--- a/lib/pundit/configuration.rb
+++ b/lib/pundit/configuration.rb
@@ -1,0 +1,11 @@
+module Pundit
+  class Configuration
+    def suffix
+      @suffix ||= "Policy".freeze
+    end
+
+    def suffix=(suffix)
+      @suffix = suffix.freeze
+    end
+  end
+end

--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -80,7 +80,7 @@ module Pundit
         subject.class.policy_class
       else
         klass = find_class_name(subject)
-        "#{klass}#{SUFFIX}"
+        "#{klass}#{Pundit.configuration.suffix}"
       end
     end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe Pundit::Configuration do
+  let(:configuration) { described_class.new }
+
+  describe "#suffix" do
+    it "returns the assigned suffix" do
+      configuration.suffix = "Suffix"
+      expect(configuration.suffix).to eql "Suffix"
+    end
+
+    it "assigns and returns `Policy` as the suffix if one wasn't already assigned" do
+      expect(configuration.suffix).to eql "Policy"
+    end
+  end
+end

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -18,6 +18,15 @@ describe Pundit do
   let(:wiki) { Wiki.new }
   let(:thread) { Thread.new }
 
+  describe ".configure" do
+    it "sets the suffix" do
+      Pundit.configure { |c| c.suffix = "Suffix" }
+      expect(Pundit.configuration.suffix).to eql "Suffix"
+
+      Pundit.remove_instance_variable(:@configuration)
+    end
+  end
+
   describe ".authorize" do
     it "infers the policy and authorizes based on it" do
       expect(Pundit.authorize(user, post, :update?)).to be_truthy


### PR DESCRIPTION
Pundit uses a `SUFFIX` constant for locating Policy classes inferred
from objects passed to the authorization helpers. It is very helpful to
override this suffix in cases where the `Policy` keyword is not
preferred.

As an example, in an application where insurance policies are managed,
introducing the `Policy` keyword to the domain language can cause logic
to get confusing.

To allow applications to override this suffix without removing and
reassigning the constant, this commit introduces a configuration class
to the gem that allows developers to define an configuration block in an
initializer to override this value.

This could be expanded upon later by either adding things to the
configuration or dynamically defining the `policy` and `policy!` helpers
to instead use the configured suffix.

Appropriately this commit also updates the documentation to describe
configuring this suffix which remains `Policy` by default.