### PR TITLE
Change namespace of Pundit::Error -> Pundit::PunditError

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -16,10 +16,10 @@ module Pundit
   module Generators; end
 
   # @api private
-  class Error < StandardError; end
+  class PunditError < StandardError; end
 
   # Error that will be raised when authorization has failed
-  class NotAuthorizedError < Error
+  class NotAuthorizedError < PunditError
     attr_reader :query, :record, :policy
 
     def initialize(options = {})
@@ -38,18 +38,18 @@ module Pundit
   end
 
   # Error that will be raised if a policy or policy scope constructor is not called correctly.
-  class InvalidConstructorError < Error; end
+  class InvalidConstructorError < PunditError; end
 
   # Error that will be raised if a controller action has not called the
   # `authorize` or `skip_authorization` methods.
-  class AuthorizationNotPerformedError < Error; end
+  class AuthorizationNotPerformedError < PunditError; end
 
   # Error that will be raised if a controller action has not called the
   # `policy_scope` or `skip_policy_scope` methods.
   class PolicyScopingNotPerformedError < AuthorizationNotPerformedError; end
 
   # Error that will be raised if a policy or policy scope is not defined.
-  class NotDefinedError < Error; end
+  class NotDefinedError < PunditError; end
 
   extend ActiveSupport::Concern
 


### PR DESCRIPTION
Fixes https://github.com/varvet/pundit/issues/542

Issue introduced by commit https://github.com/varvet/pundit/commit/a21ad899a70374797df1fd905f3966d8f77a6442

**Description:**

Pundit's error classes are namespaced within the `Pundit` module, which is intended to be `include`d into a class for policy functionality. Because of the way Ruby does lookups, that means that any class where you `include Pundit` has the following behavior:

```ruby
class Foo < ActiveRecord::Base
  include Pundit

  def self.bar
    raise Error
  end
end
```

```bash
2.3.3 :001 > Foo.bar
Pundit::Error: Pundit::Error
	from (irb):1
```

The same goes for `NotAuthorizedError`, `AuthorizationNotPerformedError`, etc., but they are of less concern than the common constant `Error`.

**Solution:**

Renamed the `Error` class in the `Pundit` module to `PunditError`.

**Why:**

This doesn't fix the fact that Pundit's errors are still included along with the rest of the module at the same scope as the inclusion. However, the only really nasty one (given that there are just a handful) is `Pundit::Error`, since `Error` is _fairly likely_ to have collisions considering how common the name is.

It doesn't make sense to change the namespacing of the errors (e.g., `Pundit::NotAuthorizedError -> Pundit::PunditErrors::NotAuthorizedError` or similar) because they are part of the public API and would be a breaking change. `Pundit::Error`, on the other hand, is *not* documented as part of the API, and in fact is marked as *private*.

Considering it's private and is only used as a base class from which the others inherit, it is not a breaking change to rename `Pundit::Error` to `Pundit::PunditError`.

**Notes:**

From CONTRIBUTING.md:

> **Add tests!** Your patch won't be accepted if it doesn't have tests.

I haven't included any tests as this is a simple rename, is only used in one file, changes no logic, and tests already cover the relevant child classes (and I've confirmed that all tests still pass)—hope that's acceptable.

> **Document any change in behaviour.** Make sure the README and any other relevant documentation are kept up-to-date.

This error class has always been marked private, and as such is not mentioned in the README nor in the API documentation, so fortunately there is no documentation to update.

**Anyway:**

Thanks for maintaining this gem. It's a pleasure to use 😃