### PR TITLE
add class configuration for a fallback_policy

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -54,6 +54,14 @@ module Pundit
   extend ActiveSupport::Concern
 
   class << self
+    def fallback_policy
+      @fallback_policy
+    end
+
+    def fallback_policy=(policy)
+      @fallback_policy = policy
+    end
+    
     # Retrieves the policy for the given record, initializing it with the
     # record and user and finally throwing an error if the user is not
     # authorized to perform the given action.

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -61,7 +61,7 @@ module Pundit
     def fallback_policy=(policy)
       @fallback_policy = policy
     end
-    
+
     # Retrieves the policy for the given record, initializing it with the
     # record and user and finally throwing an error if the user is not
     # authorized to perform the given action.

--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -36,8 +36,10 @@ module Pundit
     def policy
       klass = find(object)
 
-      if klass.is_a?(String)
-        klass = klass.safe_constantize
+      klass = if klass.is_a?(String)
+        klass.safe_constantize
+      else
+        klass
       end
 
       klass || Pundit.fallback_policy

--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -35,7 +35,12 @@ module Pundit
     #
     def policy
       klass = find(object)
-      klass.is_a?(String) ? klass.safe_constantize : klass
+
+      if klass.is_a?(String)
+        klass = klass.safe_constantize
+      end
+
+      klass || Pundit.fallback_policy
     end
 
     # @return [Scope{#resolve}] scope class which can resolve to a scope

--- a/spec/policy_finder_spec.rb
+++ b/spec/policy_finder_spec.rb
@@ -47,12 +47,40 @@ describe Pundit::PolicyFinder do
         allow(subject).to receive(:find).and_return nil
         expect(subject.policy).to eq nil
       end
+
+      context "with a fallback_policy" do
+        around(:each) do |example|
+          previous_policy = Pundit.fallback_policy
+          Pundit.fallback_policy = NilClassPolicy
+          example.run
+          Pundit.fallback_policy = previous_policy
+        end
+
+        it "returns the fallback_policy" do
+          allow(subject).to receive(:find).and_return nil
+          expect(subject.policy).to eq NilClassPolicy
+        end
+      end
     end
 
     context "with a string that can't be constantized" do
       it "returns nil" do
         allow(subject).to receive(:find).and_return "FooPolicy"
         expect(subject.policy).to eq nil
+      end
+
+      context "with a fallback_policy" do
+        around(:each) do |example|
+          previous_policy = Pundit.fallback_policy
+          Pundit.fallback_policy = NilClassPolicy
+          example.run
+          Pundit.fallback_policy = previous_policy
+        end
+
+        it "returns the fallback_policy" do
+          allow(subject).to receive(:find).and_return "FooPolicy"
+          expect(subject.policy).to eq NilClassPolicy
+        end
       end
     end
   end

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -27,6 +27,34 @@ describe Pundit do
       expect(Pundit.authorize(user, post, :create?, policy_class: PublicationPolicy)).to be_truthy
     end
 
+    context "with a missing policy class" do
+      context "with a fallback_policy" do
+        around(:each) do |example|
+          previous_policy = Pundit.fallback_policy
+          Pundit.fallback_policy = NilClassPolicy
+          example.run
+          Pundit.fallback_policy = previous_policy
+        end
+
+        it "authorizes based on the fallback_policy" do
+          expect { Pundit.authorize(user, article, :show?) }.to raise_error(Pundit::NotAuthorizedError)
+        end
+      end
+
+      context "without a fallback_policy" do
+        around(:each) do |example|
+          previous_policy = Pundit.fallback_policy
+          Pundit.fallback_policy = nil
+          example.run
+          Pundit.fallback_policy = previous_policy
+        end
+
+        it "raises an error on a missing policy class" do
+          expect { Pundit.authorize(user, article, :show?) }.to raise_error(Pundit::NotDefinedError)
+        end
+      end
+    end
+
     it "works with anonymous class policies" do
       expect(Pundit.authorize(user, article_tag, :show?)).to be_truthy
       expect { Pundit.authorize(user, article_tag, :destroy?) }.to raise_error(Pundit::NotAuthorizedError)


### PR DESCRIPTION
I saw this related issue: https://github.com/varvet/pundit/issues/321 and a [SO solution](https://stackoverflow.com/questions/27522622/how-to-use-a-default-app-policies-application-policy-rb) that suggests rescuing NotDefinedError.

Our application has a lot of roles. It means all policies would have a case statement on the role, and each new role would require editing all the policies. For similar roles, we couldn't just copy a folder and tweak a few files, we'd have to open all the polices and say `old_role || similar_role`.

A solution I'm trying is something like this:
```
def authorize(record, query = nil, options = {})
  role = role(pundit_user)

  super([:users, role.to_sym, record].flatten, query, options)
end
```

So we'll defined a policy per model, per role. However, that's also a lot of files. When the policy will just return false, I'd rather not create the policy file. I could rescue the NotDefinedError, but this isn't really an exception. I was thinking a fallback policy like this would work:

```
class Users::FallbackPolicy
  attr_reader :user, :record

  def initialize(user, record)
    @user = user
    @record = record
  end

  def method_missing(method, *args, &block)
    if method[-1] == '?'
      false
    else
      super
    end
  end

  class Scope
    attr_reader :user, :scope

    def initialize(user, scope)
      raise "Not Applicable"
    end
  end
end
```

Is this use case compelling enough to add support to pundit and if so, is this an acceptable implementation?