### PR TITLE
CI matrix: add 2.6.0, update to jruby-9.2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 before_install:
   - gem update --system
   - gem install bundler
@@ -13,9 +12,10 @@ matrix:
     - rvm: 2.3.5
     - rvm: 2.4.2
     - rvm: 2.5.1
+    - rvm: 2.6.0
     - rvm: jruby-9.1.8.0
       env:
         - JRUBY_OPTS="--debug"
-    - rvm: jruby-9.2.0.0
+    - rvm: jruby-9.2.5.0
       env:
         - JRUBY_OPTS="--debug"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
   include:
     - rvm: 2.5.1
       script: bundle exec rake rubocop # ONLY lint once, first
-    - rvm: 2.1
-    - rvm: 2.2.8
     - rvm: 2.3.5
     - rvm: 2.4.2
     - rvm: 2.5.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 before_install:
-  - gem update --system
   - gem install bundler
 
 matrix:


### PR DESCRIPTION
This PR updates the CI matrix to

- use latest JRuby, 9.2.5.0. See the [JRuby 9.2.5.0 release blog post](https://www.jruby.org/2018/12/06/jruby-9-2-5-0.html)
- add Ruby 2.6.0
- remove an old Travis setting `sudo: false`. See [Travis blog post](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)