### PR TITLE
CI: Use 2.6.1, jruby-9.2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ matrix:
     - rvm: 2.3.5
     - rvm: 2.4.2
     - rvm: 2.5.1
-    - rvm: 2.6.0
+    - rvm: 2.6.1
     - rvm: jruby-9.1.8.0
       env:
         - JRUBY_OPTS="--debug"
-    - rvm: jruby-9.2.5.0
+    - rvm: jruby-9.2.6.0
       env:
         - JRUBY_OPTS="--debug"


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.6.0.

[JRuby 9.2.6.0 release blog post](https://www.jruby.org/2019/02/11/jruby-9-2-6-0.html)