### PR TITLE
return a safer default NotAuthorizedError message

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -30,7 +30,7 @@ module Pundit
         @record = options[:record]
         @policy = options[:policy]
 
-        message = options.fetch(:message) { "not allowed to #{query} this #{record.inspect}" }
+        message = options.fetch(:message) { "not allowed to #{query} this #{record.class}" }
       end
 
       super(message)

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -36,7 +36,7 @@ describe Pundit do
       # rubocop:disable Style/MultilineBlockChain
       expect do
         Pundit.authorize(user, post, :destroy?)
-      end.to raise_error(Pundit::NotAuthorizedError, "not allowed to destroy? this #<Post>") do |error|
+      end.to raise_error(Pundit::NotAuthorizedError, "not allowed to destroy? this Post") do |error|
         expect(error.query).to eq :destroy?
         expect(error.record).to eq post
         expect(error.policy).to eq Pundit.policy(user, post)


### PR DESCRIPTION
Returning an `.inspect`ed object when not being authorized seems dangerous. If projects that use this gem just pass along Pundit's error message, unauthorized users could still see information about the record they're not supposed to see.

```ruby
class CheckingAccount
  def initialize(balance)
    @balance = balance
  end
end

class CheckingAccountPolicy < Struct.new(:user, :checking_account)
  def show?
    false
  end
end

user = OpenStruct.new
Pundit.authorize(user, CheckingAccount.new(1000), :show?)
=> Pundit::NotAuthorizedError: not allowed to show? this #<CheckingAccount:0x00007fe16d26cb08 @balance=1000>
```

In this example, even though the user is not authorized to see this `CheckingAccount`, the error message returns the `balance` of it anyway.

Proposing changing this to just returning the object's class so the message would instead look like:
```ruby

Pundit::NotAuthorizedError: not allowed to show? this CheckingAccount
```