### PR TITLE
CI: use 2.4.6, 2.5.5, 2.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ before_install:
 
 matrix:
   include:
-    - rvm: 2.5.1
+    - rvm: 2.5.1 # Pre-installed Ruby version
       script: bundle exec rake rubocop # ONLY lint once, first
     - rvm: 2.1
     - rvm: 2.2
     - rvm: 2.3.5
     - rvm: 2.4.2
-    - rvm: 2.5.1
-    - rvm: 2.6.1
+    - rvm: 2.5.5
+    - rvm: 2.6.2
     - rvm: jruby-9.1.8.0
       env:
         - JRUBY_OPTS="--debug"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - rvm: 2.1
     - rvm: 2.2
     - rvm: 2.3.5
-    - rvm: 2.4.2
+    - rvm: 2.4.6
     - rvm: 2.5.5
     - rvm: 2.6.2
     - rvm: jruby-9.1.8.0


### PR DESCRIPTION
This PR updates the CI matrix to use latest Ruby releases.