### PR TITLE
Only new should be except from scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ authorize individual instances.
 class ApplicationController < ActionController::Base
   include Pundit
   after_action :verify_authorized, except: :index
-  after_action :verify_policy_scoped, only: :index
+  after_action :verify_policy_scoped, except: :new
 end
 ```
 


### PR DESCRIPTION
Any time a lookup is likely be done (IE: Model.find(id)), this should also be scoped otherwise they may be able to lookup records they don't strictly have access to.

It isn't sufficient to only scope the index page.

Edit: Actually this should be except new and create.