### PR TITLE
CI: Use jruby-9.2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ matrix:
     - rvm: jruby-9.1.8.0
       env:
         - JRUBY_OPTS="--debug"
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.7.0
       env:
         - JRUBY_OPTS="--debug"


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.7.0**.

[JRuby 9.2.7.0 release blog post](https://www.jruby.org/2019/04/09/jruby-9-2-7-0.html)