### PR TITLE
Define Pundit::Error using compact style.

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -8,15 +8,17 @@ require "active_support/core_ext/object/blank"
 require "active_support/core_ext/module/introspection"
 require "active_support/dependencies/autoload"
 
+# @api private
+# To avoid name clashes with common Error naming when mixing in Pundit,
+# keep it here with compact class style definition.
+class Pundit::Error < StandardError; end # rubocop:disable Style/ClassAndModuleChildren
+
 # @api public
 module Pundit
   SUFFIX = "Policy".freeze
 
   # @api private
   module Generators; end
-
-  # @api private
-  class Error < StandardError; end
 
   # Error that will be raised when authorization has failed
   class NotAuthorizedError < Error


### PR DESCRIPTION
When defining the class with:

```ruby
module Pundit
  class Error
  end
end
```

the `Error` class is mixed in to the controller when using
`include Pundit`. This can cause issues since `Error` is a
very common class name. Using the compact style:

```ruby
class Pundit::Error
```

we avoid this, since it only creates the constant `Pundit::Error`.

Solves #542
Closes #555 #570 