### PR TITLE
Feature/implicitly change action name for crud

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,13 +707,15 @@ class PostPolicy < ApplicationPolicy
     [:title, :body]
   end
 
-  def permitted_attributes_for_edit
+  def permitted_attributes_for_update
     [:body]
   end
 end
 ```
 
 If you have defined an action-specific method on your policy for the current action, the `permitted_attributes` helper will call it instead of calling `permitted_attributes` on your controller.
+
+For CRUD convention, `permitted_attributes` will use `permitted_attributes_for_create` for actions `new` and `create`, and `permitted_attributes_for_update` for actions `edit` ad `update`.
 
 If you need to fetch parameters based on namespaces different from the suggested one, override the below method, in your controller, and return an instance of `ActionController::Parameters`.
 

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -272,6 +272,7 @@ protected
   # @return [Hash{String => Object}] the permitted attributes
   def permitted_attributes(record, action = action_name)
     policy = policy(record)
+    action = { new: :create, edit: :update }[action.to_sym] || action
     method_name = if policy.respond_to?("permitted_attributes_for_#{action}")
       "permitted_attributes_for_#{action}"
     else

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe Pundit do
   let(:user) { double }
   let(:post) { Post.new(user) }
+  let(:product) { Product.new }
   let(:customer_post) { Customer::Post.new(user) }
   let(:post_four_five_six) { PostFourFiveSix.new(user) }
   let(:comment) { Comment.new }
@@ -548,6 +549,26 @@ describe Pundit do
       )
       expect(Controller.new(double, action, params).permitted_attributes(customer_post).to_h).to eq(
         "votes" => 5
+      )
+    end
+
+    it "changes action name from new->create and edit->update" do
+      params = ActionController::Parameters.new(product: {
+        name: "Hello",
+        price: 1234,
+        qty: 1000,
+        admin: true
+      })
+
+      action = "new"
+      expect(Controller.new(user, action, params).permitted_attributes(product).to_h).to eq(
+        "name" => "Hello",
+        "price" => 1234,
+        "qty" => 1000
+      )
+      action = "edit"
+      expect(Controller.new(user, action, params).permitted_attributes(product).to_h).to eq(
+        "qty" => 1000
       )
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -248,6 +248,17 @@ class ThreadPolicy < Struct.new(:user, :thread)
   end
 end
 
+class Product; end
+class ProductPolicy < Struct.new(:user, :product)
+  def permitted_attributes_for_create
+    %i[name price qty]
+  end
+
+  def permitted_attributes_for_update
+    [:qty]
+  end
+end
+
 class PostFourFiveSix < Struct.new(:user); end
 
 class CommentFourFiveSix; extend ActiveModel::Naming; end


### PR DESCRIPTION
For most simple Rails app have actions named new, create, edit and update.
action new and create should share permitted parameters. so do action edit and update.
implicitly changing action name should help people resolve issues like https://github.com/varvet/pundit/issues/544. Otherwise, it's very confusing to choose name between edit and update and the `permitted_attributes` helper does not help 😕

For example
```
class PostPolicy
  def permitted_attributes_for_update
    [:title, :content]
  end
end

class Controller
  def edit
    @post = Post.find(params[:id])
    permitted_attributes(@post)
  end
  def update
    @post = Post.find(params[:id])
    permitted_attributes(@post)
  end
end
```
`permitted_attributes(@post)` should be expected to be same for the action edit and update.