### PR TITLE
CI: Use 2.4.6, 2.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - rvm: 2.3.5
     - rvm: 2.4.6
     - rvm: 2.5.5
-    - rvm: 2.6.2
+    - rvm: 2.6.3
     - rvm: jruby-9.1.8.0
       env:
         - JRUBY_OPTS="--debug"


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known