### PR TITLE
Fix concealed `rubocop` warning.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,6 +79,7 @@ Layout/IndentationWidth:
   Enabled: false
 
 Style/TrivialAccessors:
+  Enabled: false
   ExactNameMatch: true
 
 Layout/EndAlignment:
@@ -91,9 +92,6 @@ Lint/HandleExceptions:
   Enabled: false
 
 Style/SpecialGlobalVars:
-  Enabled: false
-
-Style/TrivialAccessors:
   Enabled: false
 
 Layout/IndentHash:


### PR DESCRIPTION
This PR fixes the warning when running `rubocop`.

```
.rubocop.yml:81: `Style/TrivialAccessors` is concealed by line 96
```

The `Style/TrivialAccessors` have been defined in two places.
Instead, we can have it defined in just one place.