### PR TITLE
Fix `rubocop` obsolete configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,9 +78,6 @@ Style/SignalException:
 Layout/IndentationWidth:
   Enabled: false
 
-Style/TrivialAccessors:
-  ExactNameMatch: true
-
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
@@ -95,6 +92,7 @@ Style/SpecialGlobalVars:
 
 Style/TrivialAccessors:
   Enabled: false
+  ExactNameMatch: true
 
 Layout/IndentFirstHashElement:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,10 +90,6 @@ Lint/HandleExceptions:
 Style/SpecialGlobalVars:
   Enabled: false
 
-Style/TrivialAccessors:
-  Enabled: false
-  ExactNameMatch: true
-
 Layout/IndentFirstHashElement:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
   Exclude:
     - "gemfiles/**/*"
     - "vendor/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -101,3 +101,6 @@ Layout/IndentFirstHashElement:
 
 Style/DoubleNegation:
   Enabled: false
+
+Style/SafeNavigation:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -96,7 +96,7 @@ Style/SpecialGlobalVars:
 Style/TrivialAccessors:
   Enabled: false
 
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   Enabled: false
 
 Style/DoubleNegation:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 ruby RUBY_VERSION

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rubygems"
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -10,7 +10,7 @@ require "active_support/dependencies/autoload"
 
 # @api public
 module Pundit
-  SUFFIX = "Policy".freeze
+  SUFFIX = "Policy"
 
   # @api private
   module Generators; end

--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Pundit
   # Finds policy and scope classes for given object.
   # @api public

--- a/lib/pundit/rspec.rb
+++ b/lib/pundit/rspec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/array/conversions"
 
 module Pundit

--- a/lib/pundit/version.rb
+++ b/lib/pundit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pundit
-  VERSION = "2.0.1".freeze
+  VERSION = "2.0.1"
 end

--- a/pundit.gemspec
+++ b/pundit.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "pry"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", ">= 2.0.0"
-  gem.add_development_dependency "rubocop", "0.74.0"
+  gem.add_development_dependency "rubocop", "0.68.1"
   gem.add_development_dependency "yard"
 end

--- a/pundit.gemspec
+++ b/pundit.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "pry"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", ">= 2.0.0"
-  gem.add_development_dependency "rubocop", "0.57.2"
+  gem.add_development_dependency "rubocop", "0.74.0"
   gem.add_development_dependency "yard"
 end

--- a/pundit.gemspec
+++ b/pundit.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "pundit/version"

--- a/spec/policies/post_policy_spec.rb
+++ b/spec/policies/post_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe PostPolicy do

--- a/spec/policy_finder_spec.rb
+++ b/spec/policy_finder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Pundit::PolicyFinder do

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Pundit do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -201,9 +201,9 @@ end
 class Controller
   include Pundit
   # Mark protected methods public so they may be called in test
-  # rubocop:disable Layout/AccessModifierIndentation, Style/AccessModifierDeclarations
+  # rubocop:disable Style/AccessModifierDeclarations
   public(*Pundit.protected_instance_methods)
-  # rubocop:enable Layout/AccessModifierIndentation, Style/AccessModifierDeclarations
+  # rubocop:enable Style/AccessModifierDeclarations
 
   attr_reader :current_user, :action_name, :params
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "pundit"
 require "pundit/rspec"
 


### PR DESCRIPTION
This PR fixes the issue with the `rubocop` obsolete configuration
which was renamed from `Layout/IndentHash` to
`Layout/IndentFirstHashElement`.

With that change, some other changes were needed:
- update the `TargetRubyVersion` to 2.3.
- fix rubocop violations
- disable safe navigation with `Style/SafeNavigation`

This PR also removes the `TrivialAccessors` rule because it seems
unnecessary, see: https://github.com/varvet/pundit/pull/597#discussion_r312828652

Closes: #594 