### PR TITLE
Specify development dependencies in gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
     - rvm: jruby-9.1.8.0
       env:
         - JRUBY_OPTS="--debug"
+      jdk: openjdk8
     - rvm: jruby-9.2.7.0
       env:
         - JRUBY_OPTS="--debug"

--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,3 @@ source "https://rubygems.org"
 ruby RUBY_VERSION
 
 gemspec
-
-group :development, :test do
-  gem "actionpack"
-  gem "activemodel"
-  gem "bundler"
-  gem "pry"
-  gem "rake"
-  gem "rspec"
-  gem "rubocop"
-  gem "yard"
-end

--- a/pundit.gemspec
+++ b/pundit.gemspec
@@ -18,4 +18,12 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "activesupport", ">= 3.0.0"
+  gem.add_development_dependency "actionpack", ">= 3.0.0"
+  gem.add_development_dependency "activemodel", ">= 3.0.0"
+  gem.add_development_dependency "bundler"
+  gem.add_development_dependency "pry"
+  gem.add_development_dependency "rake"
+  gem.add_development_dependency "rspec", ">= 2.0.0"
+  gem.add_development_dependency "rubocop", "0.57.2"
+  gem.add_development_dependency "yard"
 end


### PR DESCRIPTION
This commit does two things:

1. Move development dependencies back to gemspec
2. Restrict versions of some gems

It should also be noted that the recommendation is to commit
Gemfile.lock, however in this case it is not possible to do so:

3. Why we don't commit Gemfile.lock

Each of these requires a more detailed discussion - see the commit message for details.
