### PR TITLE
Drop support for end-of-life rubies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,6 @@
 AllCops:
-  DisplayCopNames: true
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
   Exclude:
-    - "gemfiles/**/*"
-    - "vendor/**/*"
     - "lib/generators/**/*"
 
 Metrics/BlockLength:
@@ -45,9 +42,6 @@ Layout/AccessModifierIndentation:
 
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
-
-Style/FrozenStringLiteralComment:
-  Enabled: true
 
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
   include:
     - rvm: 2.5.3 # Pre-installed Ruby version
       script: bundle exec rake rubocop # ONLY lint once, first
-    - rvm: 2.1
-    - rvm: 2.2
     - rvm: 2.3.5
     - rvm: 2.4.6
     - rvm: 2.5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 before_install:
-  - gem install bundler -v 1.17.3
+  - gem install bundler
 
 matrix:
   include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Pundit
 
+## Unreleased
+
+### Removed
+
+- Dropped support for Ruby end-of-life versions: 2.1 and 2.2.
+
 ## 2.1.0 (2019-08-14)
 
 ### Fixed

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -15,7 +15,7 @@ class Pundit::Error < StandardError; end # rubocop:disable Style/ClassAndModuleC
 
 # @api public
 module Pundit
-  SUFFIX = "Policy".freeze
+  SUFFIX = "Policy"
 
   # @api private
   module Generators; end
@@ -124,7 +124,7 @@ module Pundit
     # @return [Object, nil] instance of policy class with query methods
     def policy(user, record)
       policy = PolicyFinder.new(record).policy
-      policy.new(user, pundit_model(record)) if policy
+      policy&.new(user, pundit_model(record))
     rescue ArgumentError
       raise InvalidConstructorError, "Invalid #<#{policy}> constructor is called"
     end

--- a/lib/pundit/version.rb
+++ b/lib/pundit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pundit
-  VERSION = "2.1.0".freeze
+  VERSION = "2.1.0"
 end

--- a/pundit.gemspec
+++ b/pundit.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "pry"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", ">= 2.0.0"
-  gem.add_development_dependency "rubocop", "0.57.2"
+  gem.add_development_dependency "rubocop", "0.74.0"
   gem.add_development_dependency "yard"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -201,9 +201,9 @@ end
 class Controller
   include Pundit
   # Mark protected methods public so they may be called in test
-  # rubocop:disable Layout/AccessModifierIndentation, Style/AccessModifierDeclarations
+  # rubocop:disable Style/AccessModifierDeclarations
   public(*Pundit.protected_instance_methods)
-  # rubocop:enable Layout/AccessModifierIndentation, Style/AccessModifierDeclarations
+  # rubocop:enable Style/AccessModifierDeclarations
 
   attr_reader :current_user, :action_name, :params
 


### PR DESCRIPTION
Ruby 2.1 and 2.2 are past end-of-life and we've decided to stop supporting them (#603).

Doing this allows us to update Rubocop to the latest version, and to bundle using the latest version of bundler.

Committing the Gemfile.lock has issues with JRuby, so that will be done in a separate PR.