### PR TITLE
Rubocop Housekeeping

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,12 +42,6 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
-Layout/ClosingParenthesisIndentation:
-  Enabled: false
-
-Style/OneLineConditional:
-  Enabled: false
-
 Style/AndOr:
   Enabled: false
 
@@ -75,20 +69,8 @@ Style/PercentLiteralDelimiters:
 Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
 
-Style/SignalException:
-  Enabled: false
-
-Layout/IndentationWidth:
-  Enabled: false
-
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
-
-Layout/DefEndAlignment:
-  Enabled: false
-
-Lint/HandleExceptions:
-  Enabled: false
 
 Style/DoubleNegation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,29 +30,8 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Enabled: false
 
-Style/StructInheritance:
-  Enabled: false
-
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-
-Style/StringLiteralsInInterpolation:
-  EnforcedStyle: double_quotes
-
-Style/AndOr:
-  Enabled: false
-
-Style/Not:
-  Enabled: false
-
-Style/FrozenStringLiteralComment:
-  Enabled: true
-
-Documentation:
-  Enabled: false # TODO: Enable again once we have more docs
 
 Layout/CaseIndentation:
   EnforcedStyle: case
@@ -61,16 +40,37 @@ Layout/CaseIndentation:
     - end
   IndentOneStep: true
 
-Style/PercentLiteralDelimiters:
-  PreferredDelimiters:
-    '%w': "[]"
-    '%W': "[]"
-
 Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
 
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
+Style/FrozenStringLiteralComment:
+  Enabled: true
+
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%w': "[]"
+    '%W': "[]"
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+Style/StructInheritance:
+  Enabled: false
+
+Style/AndOr:
+  Enabled: false
+
+Style/Not:
+  Enabled: false
+
 Style/DoubleNegation:
   Enabled: false
+
+Documentation:
+  Enabled: false # TODO: Enable again once we have more docs

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,8 +90,5 @@ Layout/DefEndAlignment:
 Lint/HandleExceptions:
   Enabled: false
 
-Style/SpecialGlobalVars:
-  Enabled: false
-
 Style/DoubleNegation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,6 +54,9 @@ Style/AndOr:
 Style/Not:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Enabled: true
+
 Documentation:
   Enabled: false # TODO: Enable again once we have more docs
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,8 +90,5 @@ Lint/HandleExceptions:
 Style/SpecialGlobalVars:
   Enabled: false
 
-Layout/IndentHash:
-  Enabled: false
-
 Style/DoubleNegation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,9 +78,6 @@ Style/SignalException:
 Layout/IndentationWidth:
   Enabled: false
 
-Style/TrivialAccessors:
-  ExactNameMatch: true
-
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
@@ -91,9 +88,6 @@ Lint/HandleExceptions:
   Enabled: false
 
 Style/SpecialGlobalVars:
-  Enabled: false
-
-Style/TrivialAccessors:
   Enabled: false
 
 Layout/IndentHash:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 ruby RUBY_VERSION

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rubygems"
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"

--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Pundit
   # Finds policy and scope classes for given object.
   # @api public

--- a/lib/pundit/rspec.rb
+++ b/lib/pundit/rspec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/array/conversions"
 
 module Pundit

--- a/pundit.gemspec
+++ b/pundit.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/varvet/pundit"
   gem.license       = "MIT"
 
-  gem.files         = `git ls-files`.split($/)
+  gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]

--- a/pundit.gemspec
+++ b/pundit.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "pundit/version"

--- a/spec/policies/post_policy_spec.rb
+++ b/spec/policies/post_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe PostPolicy do

--- a/spec/policy_finder_spec.rb
+++ b/spec/policy_finder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Pundit::PolicyFinder do

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -518,11 +518,13 @@ describe Pundit do
 
   describe "#permitted_attributes" do
     it "checks policy for permitted attributes" do
-      params = ActionController::Parameters.new(post: {
-        title: "Hello",
-        votes: 5,
-        admin: true
-      })
+      params = ActionController::Parameters.new(
+        post: {
+          title: "Hello",
+          votes: 5,
+          admin: true
+        }
+      )
 
       action = "update"
 
@@ -534,11 +536,13 @@ describe Pundit do
     end
 
     it "checks policy for permitted attributes for record of a ActiveModel type" do
-      params = ActionController::Parameters.new(customer_post: {
-        title: "Hello",
-        votes: 5,
-        admin: true
-      })
+      params = ActionController::Parameters.new(
+        customer_post: {
+          title: "Hello",
+          votes: 5,
+          admin: true
+        }
+      )
 
       action = "update"
 
@@ -554,24 +558,28 @@ describe Pundit do
 
   describe "#permitted_attributes_for_action" do
     it "is checked if it is defined in the policy" do
-      params = ActionController::Parameters.new(post: {
-        title: "Hello",
-        body: "blah",
-        votes: 5,
-        admin: true
-      })
+      params = ActionController::Parameters.new(
+        post: {
+          title: "Hello",
+          body: "blah",
+          votes: 5,
+          admin: true
+        }
+      )
 
       action = "revise"
       expect(Controller.new(user, action, params).permitted_attributes(post).to_h).to eq("body" => "blah")
     end
 
     it "can be explicitly set" do
-      params = ActionController::Parameters.new(post: {
-        title: "Hello",
-        body: "blah",
-        votes: 5,
-        admin: true
-      })
+      params = ActionController::Parameters.new(
+        post: {
+          title: "Hello",
+          body: "blah",
+          votes: 5,
+          admin: true
+        }
+      )
 
       action = "update"
       expect(Controller.new(user, action, params).permitted_attributes(post, :revise).to_h).to eq("body" => "blah")

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Pundit do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "pundit"
 require "pundit/rspec"
 


### PR DESCRIPTION
The intention of this PR is to clean up the Rubocop config, and make it forwards-compatible as much as possible without dropping support for ruby 2.1 and 2.2.

There are a lot of things in the rubocop config which don't really need to be
there: a number seem to have been copied from some other project. 

Where there are no issues, or the issues can be easily fixed to be in line with the rubocop
defaults, then it feels like a good idea to remove these exceptions, at least
in part because it insulates us from future changes to the cop name or options.