### PR TITLE
CI: Use jruby-9.2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ matrix:
       env:
         - JRUBY_OPTS="--debug"
       jdk: openjdk8
-    - rvm: jruby-9.2.7.0
+    - rvm: jruby-9.2.8.0
       env:
         - JRUBY_OPTS="--debug"


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.8.0**.

[JRuby 9.2.8.0 release blog post](https://www.jruby.org/2019/08/12/jruby-9-2-8-0.html)