### PR TITLE
Update default CI ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
 
 matrix:
   include:
-    - rvm: 2.5.1 # Pre-installed Ruby version
+    - rvm: 2.5.3 # Pre-installed Ruby version
       script: bundle exec rake rubocop # ONLY lint once, first
     - rvm: 2.1
     - rvm: 2.2


### PR DESCRIPTION
The point of this initial build is to be fast and to run rubocop by
using the default, without building a ruby version. However, since the
default version has now changed, we're always building a ruby version
for that check.

The default version can be seen here:

  https://docs.travis-ci.com/user/reference/xenial/#ruby-support