### PR TITLE
CI: Drop the gem install bundler step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
-before_install:
-  - gem install bundler
 
 matrix:
   include:


### PR DESCRIPTION
This PR tries to get rid of the `gem install bundler`, hoping that we already have a new-enough bundler from `rvm`.