### PR TITLE
Only install bundler on needy version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: ruby
-before_install:
-  - gem install bundler
 
 matrix:
   include:
     - name: "RuboCop lint on pre-installed Ruby version"
       rvm: 2.5.3 # Pre-installed Ruby version
+      before_install:
+        - gem install bundler
       script: bundle exec rake rubocop # ONLY lint once, first
     - rvm: 2.3.5
     - rvm: 2.4.6


### PR DESCRIPTION
It seems that on the preinstalled version of ruby we (sometimes?) don't
get a preinstalled bundler for free, but on rubies which we build and
install ourselves we do.

By not installing before every single build we save ourselves a few
seconds in the overall build.