### PR TITLE
Make generators comply with Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.3
   Exclude:
-    - "lib/generators/**/*"
+    - "lib/generators/**/templates/**/*"
 
 Metrics/BlockLength:
   Exclude:

--- a/lib/generators/pundit/install/install_generator.rb
+++ b/lib/generators/pundit/install/install_generator.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module Pundit
   module Generators
     class InstallGenerator < ::Rails::Generators::Base
-      source_root File.expand_path('templates', __dir__)
+      source_root File.expand_path("templates", __dir__)
 
       def copy_application_policy
-        template 'application_policy.rb', 'app/policies/application_policy.rb'
+        template "application_policy.rb", "app/policies/application_policy.rb"
       end
     end
   end

--- a/lib/generators/pundit/install/templates/application_policy.rb
+++ b/lib/generators/pundit/install/templates/application_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationPolicy
   attr_reader :user, :record
 

--- a/lib/generators/pundit/policy/policy_generator.rb
+++ b/lib/generators/pundit/policy/policy_generator.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module Pundit
   module Generators
     class PolicyGenerator < ::Rails::Generators::NamedBase
-      source_root File.expand_path('templates', __dir__)
+      source_root File.expand_path("templates", __dir__)
 
       def create_policy
-        template 'policy.rb', File.join('app/policies', class_path, "#{file_name}_policy.rb")
+        template "policy.rb", File.join("app/policies", class_path, "#{file_name}_policy.rb")
       end
 
       hook_for :test_framework

--- a/lib/generators/rspec/policy_generator.rb
+++ b/lib/generators/rspec/policy_generator.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module Rspec
   module Generators
     class PolicyGenerator < ::Rails::Generators::NamedBase
-      source_root File.expand_path('templates', __dir__)
+      source_root File.expand_path("templates", __dir__)
 
       def create_policy_spec
-        template 'policy_spec.rb', File.join('spec/policies', class_path, "#{file_name}_policy_spec.rb")
+        template "policy_spec.rb", File.join("spec/policies", class_path, "#{file_name}_policy_spec.rb")
       end
     end
   end

--- a/lib/generators/test_unit/policy_generator.rb
+++ b/lib/generators/test_unit/policy_generator.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module TestUnit
   module Generators
     class PolicyGenerator < ::Rails::Generators::NamedBase
-      source_root File.expand_path('templates', __dir__)
+      source_root File.expand_path("templates", __dir__)
 
       def create_policy_test
-        template 'policy_test.rb', File.join('test/policies', class_path, "#{file_name}_policy_test.rb")
+        template "policy_test.rb", File.join("test/policies", class_path, "#{file_name}_policy_test.rb")
       end
     end
   end


### PR DESCRIPTION
There doesn't seem to be any particular reason to exclude these. It's at
least nice to have consistent use of quotes within the same file.

This does run the risk of imposing our specific rubocop rules on other
people's code (double vs single quotes is the cause of holy wars), but
if anything obviously awful comes up, we can exclude generators from
that specific rule.