### PR TITLE
Report test coverage to CodeClimate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.coverage
 .yardoc
 Gemfile.lock
 InstalledFiles

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ matrix:
         - gem install bundler
       script: bundle exec rake rubocop # ONLY lint once, first
     - rvm: 2.3.5
+      before_script:
+        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        - chmod +x ./cc-test-reporter
+        - ./cc-test-reporter before-build
+      after_script:
+        - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
     - rvm: 2.4.6
     - rvm: 2.5.5
     - rvm: 2.6.3

--- a/pundit.gemspec
+++ b/pundit.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", ">= 3.0.0"
   gem.add_development_dependency "rubocop", "0.74.0"
+  gem.add_development_dependency "simplecov", ">= 0.17.0"
   gem.add_development_dependency "yard"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+require "simplecov"
+SimpleCov.start do
+  add_filter "/spec/"
+end
+
 require "pundit"
 require "pundit/rspec"
 


### PR DESCRIPTION
Coverage gets generated on every build, but we only need to send it for
one build. Pick the first one - otherwise we get eg:

        ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
        time="2019-08-22T12:37:01Z" level=warning msg="Conflict when uploading: A test report for commit 6dabaaa6cd7e4c5c51dc538e4fbb7861ca433d8e already exists, skipping upload"

Config from here:

https://docs.codeclimate.com/docs/travis-ci-test-coverage#section-travis-ci-single-test-suite-non-parallel-builds