### PR TITLE
Drop support for RSpec 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Removed
 
 - Dropped support for Ruby end-of-life versions: 2.1 and 2.2.
+- Dropped support for RSpec 2
 
 ## 2.1.0 (2019-08-14)
 

--- a/lib/pundit/rspec.rb
+++ b/lib/pundit/rspec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/array/conversions"
-
 module Pundit
   module RSpec
     module Matchers
@@ -74,17 +72,9 @@ module Pundit
 end
 
 RSpec.configure do |config|
-  if RSpec::Core::Version::STRING.split(".").first.to_i >= 3
-    config.include(
-      Pundit::RSpec::PolicyExampleGroup,
-      type: :policy,
-      file_path: %r{spec/policies}
-    )
-  else
-    config.include(
-      Pundit::RSpec::PolicyExampleGroup,
-      type: :policy,
-      example_group: { file_path: %r{spec/policies} }
-    )
-  end
+  config.include(
+    Pundit::RSpec::PolicyExampleGroup,
+    type: :policy,
+    file_path: %r{spec/policies}
+  )
 end

--- a/pundit.gemspec
+++ b/pundit.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "rspec", ">= 2.0.0"
+  gem.add_development_dependency "rspec", ">= 3.0.0"
   gem.add_development_dependency "rubocop", "0.74.0"
   gem.add_development_dependency "yard"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,22 +11,6 @@ require "active_support/core_ext"
 require "active_model/naming"
 require "action_controller/metal/strong_parameters"
 
-I18n.enforce_available_locales = false
-
-module PunditSpecHelper
-  extend RSpec::Matchers::DSL
-
-  matcher :be_truthy do
-    match do |actual|
-      actual
-    end
-  end
-end
-
-RSpec.configure do |config|
-  config.include PunditSpecHelper
-end
-
 class PostPolicy < Struct.new(:user, :post)
   class Scope < Struct.new(:user, :scope)
     def resolve


### PR DESCRIPTION
I couldn't work out if it's officially unsupported, but RSpec3 came out
around 5 years ago and we had a fair amount of code which seemed to
only be there to support it.