### PR TITLE
Scopes have private attr_readers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,9 +37,6 @@ Layout/CaseIndentation:
     - end
   IndentOneStep: true
 
-Layout/AccessModifierIndentation:
-  EnforcedStyle: outdent
-
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - `.authorize` and `#authorize` return the instance, even for namespaced
   policies (#626)
 
+### Changed
+
+- Generate application scope with `protected` attr_readers. (#616)
+
 ### Removed
 
 - Dropped support for Ruby end-of-life versions: 2.1 and 2.2. (#604)

--- a/README.md
+++ b/README.md
@@ -220,8 +220,6 @@ define a class called a policy scope. It can look something like this:
 ``` ruby
 class PostPolicy < ApplicationPolicy
   class Scope
-    attr_reader :user, :scope
-
     def initialize(user, scope)
       @user  = user
       @scope = scope
@@ -234,6 +232,10 @@ class PostPolicy < ApplicationPolicy
         scope.where(published: true)
       end
     end
+
+    private
+
+    attr_reader :user, :scope
   end
 
   def update?

--- a/lib/generators/pundit/install/templates/application_policy.rb
+++ b/lib/generators/pundit/install/templates/application_policy.rb
@@ -37,8 +37,6 @@ class ApplicationPolicy
   end
 
   class Scope
-    attr_reader :user, :scope
-
     def initialize(user, scope)
       @user = user
       @scope = scope
@@ -47,5 +45,9 @@ class ApplicationPolicy
     def resolve
       scope.all
     end
+
+    private
+
+    attr_reader :user, :scope
   end
 end

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -144,7 +144,7 @@ module Pundit
       raise InvalidConstructorError, "Invalid #<#{policy}> constructor is called"
     end
 
-  private
+    private
 
     def pundit_model(record)
       record.is_a?(Array) ? record.last : record
@@ -167,7 +167,7 @@ module Pundit
     end
   end
 
-protected
+  protected
 
   # @return [Boolean] whether authorization has been performed, i.e. whether
   #                   one {#authorize} or {#skip_authorization} has been called
@@ -317,7 +317,7 @@ protected
     current_user
   end
 
-private
+  private
 
   def pundit_policy_scope(scope)
     policy_scopes[scope] ||= Pundit.policy_scope!(pundit_user, scope)

--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -68,7 +68,7 @@ module Pundit
       end
     end
 
-  private
+    private
 
     def find(subject)
       if subject.is_a?(Array)


### PR DESCRIPTION
- Generate application scope with `protected` attr readers
- Update documentation to suggest that other scopes should use `private`

There doesn't seem to be a use case for accessing the initialisation
parameters on scopes. In general keeping the public interface of classes
as small as possible can help to keep code decoupled.

The application scope readers need to be protected rather than private  since
other scopes are expected to inherit from it