### PR TITLE
Prefer single-quoted strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Sponsored by:
 ## Installation
 
 ``` ruby
-gem "pundit"
+gem 'pundit'
 ```
 
 Include Pundit in your application controller:


### PR DESCRIPTION
Prefer single-quoted strings when you don't need string interpolation or special symbols