### PR TITLE
Ability for rspec matcher to take additional args

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,6 +767,12 @@ describe PostPolicy do
       expect(subject).to permit(User.new(admin: false), Post.new(published: false))
     end
   end
+
+  permissions :custom_with_args? do
+    it "is successful if correct args are passed" do
+      expect(subject).to permit(User.new(admin: false), Post.new(published: false), false)
+    end
+  end
 end
 ```
 

--- a/lib/pundit/rspec.rb
+++ b/lib/pundit/rspec.rb
@@ -6,17 +6,17 @@ module Pundit
       extend ::RSpec::Matchers::DSL
 
       # rubocop:disable Metrics/BlockLength
-      matcher :permit do |user, record|
+      matcher :permit do |user, record, *args|
         match_proc = lambda do |policy|
           @violating_permissions = permissions.find_all do |permission|
-            !policy.new(user, record).public_send(permission)
+            !policy.new(user, record).public_send(permission, *args)
           end
           @violating_permissions.empty?
         end
 
         match_when_negated_proc = lambda do |policy|
           @violating_permissions = permissions.find_all do |permission|
-            policy.new(user, record).public_send(permission)
+            policy.new(user, record).public_send(permission, *args)
           end
           @violating_permissions.empty?
         end

--- a/spec/policies/post_policy_spec.rb
+++ b/spec/policies/post_policy_spec.rb
@@ -19,4 +19,32 @@ describe PostPolicy do
       end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
     end
   end
+
+  permissions :custom_action? do
+    context "passing in extra values" do
+      context "argument is true" do
+        it "is successful" do
+          should permit(user, own_post, true)
+        end
+      end
+      context "argument is false" do
+        it "fails" do
+          should_not permit(user, own_post, false)
+        end
+      end
+    end
+  end
+
+  permissions :two_arguments? do
+    context "both arguments are true" do
+      it "is successful" do
+        should permit(user, own_post, true, true)
+      end
+    end
+    context "one argument is false" do
+      it "fails" do
+        should_not permit(user, own_post, true, false)
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,14 @@ class PostPolicy < Struct.new(:user, :post)
     true
   end
 
+  def custom_action?(flag)
+    flag
+  end
+
+  def two_arguments?(flag1, flag2)
+    flag1 && flag2
+  end
+
   def permitted_attributes
     if post.user == user
       %i[title votes]


### PR DESCRIPTION
Sometimes we need to add custom args to our policy methods, and would be
nice to use the built in rspec matchers to test these policies. This
allows arbitrary arguments to be passed in to the policy.