### PR TITLE
Raise error when try to authorize nilclass

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -214,6 +214,8 @@ protected
   # @raise [NotAuthorizedError] if the given query method returned false
   # @return [Object] Always returns the passed object record
   def authorize(record, query = nil, policy_class: nil)
+    raise NotAuthorizedError unless record
+
     query ||= "#{action_name}?"
 
     @_pundit_policy_authorized = true


### PR DESCRIPTION
Can we add this change to when someone try to authorize some nilclass?