### PR TITLE
Add ability to use different error messages for same policy rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,9 +538,9 @@ en:
 Of course, this is just an example. Pundit is agnostic as to how you implement
 your error messaging.
 
-## Deep error messages customisation
+## Multiple error messages per one policy action
 
-If you have different authorization deny reasons you want to inform user with descriptive message then:
+If there are multiple reasons that authorization can be denied, you can show different messages by raising exceptions in your policy:
 
 In your policy class raise `Pundit::NotAuthorizedError` with custom error message or I18n key in `reason` argument:
 
@@ -563,10 +563,19 @@ end
 Then you can get this error message in exception handler:
 ```ruby
 rescue_from Pundit::NotAuthorizedError do |e|
-  message = e.reason ? I18n.t("errors.#{e.reason}") : e.message
+  message = e.reason ? I18n.t("pundit.errors.#{e.reason}") : e.message
   flash[:error] = message, scope: "pundit", default: :default
   redirect_to(request.referrer || root_path)
 end
+```
+
+```yaml
+en:
+  pundit:
+    errors:
+      user:
+        paid_subscription_required: 'Paid subscription is required'
+        project_limit_reached: 'Project limit is reached'
 ```
 
 ## Manually retrieving policies and scopes

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -22,7 +22,7 @@ module Pundit
 
   # Error that will be raised when authorization has failed
   class NotAuthorizedError < Error
-    attr_reader :query, :record, :policy
+    attr_reader :query, :record, :policy, :reason
 
     def initialize(options = {})
       if options.is_a? String
@@ -31,6 +31,7 @@ module Pundit
         @query  = options[:query]
         @record = options[:record]
         @policy = options[:policy]
+        @reason = options[:reason]
 
         message = options.fetch(:message) { "not allowed to #{query} this #{record.class}" }
       end


### PR DESCRIPTION
## Deep error messages customisation

There is no way to show different error messages for one policy rule now, but is matters (see example below).

When you have different authorization deny reasons you want to inform user with descriptive message then:

Extend your `ApplicationPolicy` with `message` attr and `deny!` method:

```ruby
class ApplicationPolicy
  attr_reader :message
  
  def deny!(message)
    @message = message
    false
  end
end
```

In your policy class specify custom error message in `deny!` parameter:

```ruby
class ProjectPolicy < ApplicationPolicy
  def create?
    if user.has_paid_subscription?
      if user.project_limit_reached?
        deny!(I18n.t('errors.user.project_limit_reached'))
      else
        true
      end
    else
      deny!(I18n.t('errors.user.paid_subscription_required'))
    end
  end
end
```

Then you can get this error message in exception handler:
```ruby
rescue_from Pundit::NotAuthorizedError do |e|
  # Cutom error will be in e.message
  # Also it will bein e.policy.message
  # If there was no deny! call e.policy.message will be nil
end
```