### PR TITLE
'.authorize' and '#authorize' return record even with passed record with namespace array

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -71,7 +71,7 @@ module Pundit
 
       raise NotAuthorizedError, query: query, record: record, policy: policy unless policy.public_send(query)
 
-      record
+      record.is_a?(Array) ? record.last : record
     end
 
     # Retrieves the policy scope for the given record.
@@ -222,7 +222,7 @@ protected
 
     raise NotAuthorizedError, query: query, record: record, policy: policy unless policy.public_send(query)
 
-    record
+    record.is_a?(Array) ? record.last : record
   end
 
   # Allow this action not to perform authorization.

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -25,6 +25,14 @@ describe Pundit do
       expect(Pundit.authorize(user, post, :update?)).to be_truthy
     end
 
+    it "returns the record on successful authorization" do
+      expect(Pundit.authorize(user, post, :update?)).to be(post)
+    end
+
+    it "returns the record when passed record with namespace " do
+      expect(Pundit.authorize(user, [:project, comment], :update?)).to be(comment)
+    end
+
     it "can be given a different policy class" do
       expect(Pundit.authorize(user, post, :create?, policy_class: PublicationPolicy)).to be_truthy
     end
@@ -411,6 +419,10 @@ describe Pundit do
 
     it "returns the record on successful authorization" do
       expect(controller.authorize(post)).to be(post)
+    end
+
+    it "returns the record when passed record with namespace " do
+      expect(Pundit.authorize(user, [:project, comment], :update?)).to be(comment)
     end
 
     it "can be given a different permission to check" do

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -37,16 +37,8 @@ describe Pundit do
       expect(Pundit.authorize(user, [:project, :admin, comment], :update?)).to eq(comment)
     end
 
-    it "can use headless policy" do
-      expect(Pundit.authorize(user, :publication, :create?)).to be_truthy
-    end
-
     it "returns the policy name symbol when passed record with headless policy" do
       expect(Pundit.authorize(user, :publication, :create?)).to eq(:publication)
-    end
-
-    it "can use without a particular instance" do
-      expect(Pundit.authorize(user, Post, :show?)).to be_truthy
     end
 
     it "returns the class when passed record not a particular instance" do
@@ -449,16 +441,8 @@ describe Pundit do
       expect(controller.authorize([:project, :admin, comment], :update?)).to eq(comment)
     end
 
-    it "can use headless policy" do
-      expect(controller.authorize(:publication, :create?)).to be_truthy
-    end
-
     it "returns the policy name symbol when passed record with headless policy" do
       expect(controller.authorize(:publication, :create?)).to eq(:publication)
-    end
-
-    it "can use without a particular instance" do
-      expect(controller.authorize(Post, :show?)).to be_truthy
     end
 
     it "returns the class when passed record not a particular instance" do

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -33,6 +33,26 @@ describe Pundit do
       expect(Pundit.authorize(user, [:project, comment], :update?)).to be(comment)
     end
 
+    it "returns the record when passed record with nested namespace " do
+      expect(Pundit.authorize(user, [:project, :admin, comment], :update?)).to be(comment)
+    end
+
+    it "can use headless policy" do
+      expect(Pundit.authorize(user, :publication, :create?)).to be_truthy
+    end
+
+    it "returns the policy name symbol when passed record with headless policy" do
+      expect(Pundit.authorize(user, :publication, :create?)).to be(:publication)
+    end
+
+    it "can use without a particular instance" do
+      expect(Pundit.authorize(user, Post, :show?)).to be_truthy
+    end
+
+    it "returns the class when passed record not a particular instance" do
+      expect(Pundit.authorize(user, Post, :show?)).to be(Post)
+    end
+
     it "can be given a different policy class" do
       expect(Pundit.authorize(user, post, :create?, policy_class: PublicationPolicy)).to be_truthy
     end
@@ -422,7 +442,27 @@ describe Pundit do
     end
 
     it "returns the record when passed record with namespace " do
-      expect(Pundit.authorize(user, [:project, comment], :update?)).to be(comment)
+      expect(controller.authorize([:project, comment], :update?)).to be(comment)
+    end
+
+    it "returns the record when passed record with nested namespace " do
+      expect(controller.authorize([:project, :admin, comment], :update?)).to be(comment)
+    end
+
+    it "can use headless policy" do
+      expect(controller.authorize(:publication, :create?)).to be_truthy
+    end
+
+    it "returns the policy name symbol when passed record with headless policy" do
+      expect(controller.authorize(:publication, :create?)).to be(:publication)
+    end
+
+    it "can use without a particular instance" do
+      expect(controller.authorize(Post, :show?)).to be_truthy
+    end
+
+    it "returns the class when passed record not a particular instance" do
+      expect(controller.authorize(Post, :show?)).to be(Post)
     end
 
     it "can be given a different permission to check" do

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -26,15 +26,15 @@ describe Pundit do
     end
 
     it "returns the record on successful authorization" do
-      expect(Pundit.authorize(user, post, :update?)).to be(post)
+      expect(Pundit.authorize(user, post, :update?)).to eq(post)
     end
 
     it "returns the record when passed record with namespace " do
-      expect(Pundit.authorize(user, [:project, comment], :update?)).to be(comment)
+      expect(Pundit.authorize(user, [:project, comment], :update?)).to eq(comment)
     end
 
     it "returns the record when passed record with nested namespace " do
-      expect(Pundit.authorize(user, [:project, :admin, comment], :update?)).to be(comment)
+      expect(Pundit.authorize(user, [:project, :admin, comment], :update?)).to eq(comment)
     end
 
     it "can use headless policy" do
@@ -42,7 +42,7 @@ describe Pundit do
     end
 
     it "returns the policy name symbol when passed record with headless policy" do
-      expect(Pundit.authorize(user, :publication, :create?)).to be(:publication)
+      expect(Pundit.authorize(user, :publication, :create?)).to eq(:publication)
     end
 
     it "can use without a particular instance" do
@@ -50,7 +50,7 @@ describe Pundit do
     end
 
     it "returns the class when passed record not a particular instance" do
-      expect(Pundit.authorize(user, Post, :show?)).to be(Post)
+      expect(Pundit.authorize(user, Post, :show?)).to eq(Post)
     end
 
     it "can be given a different policy class" do
@@ -438,15 +438,15 @@ describe Pundit do
     end
 
     it "returns the record on successful authorization" do
-      expect(controller.authorize(post)).to be(post)
+      expect(controller.authorize(post)).to eq(post)
     end
 
     it "returns the record when passed record with namespace " do
-      expect(controller.authorize([:project, comment], :update?)).to be(comment)
+      expect(controller.authorize([:project, comment], :update?)).to eq(comment)
     end
 
     it "returns the record when passed record with nested namespace " do
-      expect(controller.authorize([:project, :admin, comment], :update?)).to be(comment)
+      expect(controller.authorize([:project, :admin, comment], :update?)).to eq(comment)
     end
 
     it "can use headless policy" do
@@ -454,7 +454,7 @@ describe Pundit do
     end
 
     it "returns the policy name symbol when passed record with headless policy" do
-      expect(controller.authorize(:publication, :create?)).to be(:publication)
+      expect(controller.authorize(:publication, :create?)).to eq(:publication)
     end
 
     it "can use without a particular instance" do
@@ -462,7 +462,7 @@ describe Pundit do
     end
 
     it "returns the class when passed record not a particular instance" do
-      expect(controller.authorize(Post, :show?)).to be(Post)
+      expect(controller.authorize(Post, :show?)).to eq(Post)
     end
 
     it "can be given a different permission to check" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -178,6 +178,14 @@ module Project
       end
     end
   end
+
+  module Admin
+    class CommentPolicy < Struct.new(:user, :comment)
+      def update?
+        true
+      end
+    end
+  end
 end
 
 class DenierPolicy < Struct.new(:user, :record)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -158,6 +158,10 @@ class CriteriaPolicy < Struct.new(:user, :criteria); end
 
 module Project
   class CommentPolicy < Struct.new(:user, :comment)
+    def update?
+      true
+    end
+
     class Scope < Struct.new(:user, :scope)
       def resolve
         scope


### PR DESCRIPTION
Hi, Thank you for the great Gem!
This is a proposal and pull request at once.
'.authorize' and '#authorize' return passed record now.

```ruby
def show
  @post  = authorize Post.find(params[:id])
end
```

But When passing record with a namespace. return array

```ruby 
def show
  @post  = authorize [:admin, Post.find(params[:id])]
end

# @post is  [:admin, Post.find(params[:id])]
```
These methods are expected to return record not namespase array

When authorize override the helpers in AdminController to automatically apply the namespacing, This change will be very useful.

```ruby
class AdminController < ApplicationController
  def authorize(record, query = nil)
    super([:admin, record], query)
  end
end

class Admin::PostController < AdminController
  def show
    post = authorize Post.find(params[:id])
    # We don't need `authorize(post)` line!
  end
end
```

If there is a place to fix, please let me know.
best regards.
