### PR TITLE
Stop building against ruby 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Exclude:
     - "lib/generators/**/templates/**/*"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,16 @@ matrix:
       before_install:
         - gem install bundler
       script: bundle exec rake rubocop # ONLY lint once, first
-    - rvm: 2.3.5
+    - rvm: 2.4.9
       before_script:
         - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
         - chmod +x ./cc-test-reporter
         - ./cc-test-reporter before-build
       after_script:
         - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-    - rvm: 2.4.6
-    - rvm: 2.5.5
-    - rvm: 2.6.3
+    - rvm: 2.5.7
+    - rvm: 2.6.5
+    - rvm: 2.7.0-preview3
     - name: "jruby-9.1.8.0 on OpenJDK 8"
       rvm: jruby-9.1.8.0
       env:


### PR DESCRIPTION
It went end-of-life in March 2019:

https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/

Build against latest versions of other rubies