### PR TITLE
Remove calling super in included

### DIFF
--- a/lib/pundit/rspec.rb
+++ b/lib/pundit/rspec.rb
@@ -65,7 +65,6 @@ module Pundit
       def self.included(base)
         base.metadata[:type] = :policy
         base.extend Pundit::RSpec::DSL
-        super
       end
     end
   end


### PR DESCRIPTION
This commit is to remove calling `super` in included method. Because `included` is callback to include or extend modules without calling `super`