### PR TITLE
Include example of declaring #policy_class at an instance level

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,16 @@ class Post
 end
 ```
 
+Alternatively, you can declare an instance method:
+
+``` ruby
+class Post
+  def policy_class
+    PostablePolicy
+  end
+end
+```
+
 ## Just plain old Ruby
 
 As you can see, Pundit doesn't do anything you couldn't have easily done


### PR DESCRIPTION
From reading the README it wasn't clear to me that we could declare a policy_class method on the instance.

[Looking at the code](https://github.com/varvet/pundit/blob/master/lib/pundit/policy_finder.rb#L79) I saw it was possible, so I thought it would be a good idea to include that information in the README.