### PR TITLE
CI: Update JRuby 9.2 version under test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       env:
         - JRUBY_OPTS="--debug"
       jdk: openjdk8
-    - rvm: jruby-9.2.8.0
+    - rvm: jruby-9.2.11.0
       env:
         - JRUBY_OPTS="--debug"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       env:
         - JRUBY_OPTS="--debug"
       jdk: openjdk8
-    - rvm: jruby-9.2.11.0
+    - rvm: jruby-9.2.15.0
       env:
         - JRUBY_OPTS="--debug"
 


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.11.0**.

[JRuby 9.2.11.0 release blog post](https://www.jruby.org/2020/03/02/jruby-9-2-11-0.html)