### PR TITLE
Improved NotAuthorizedError message when record is a class

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -33,7 +33,13 @@ module Pundit
         @policy = options[:policy]
         @reason = options[:reason]
 
-        message = options.fetch(:message) { "not allowed to #{query} this #{record.class}" }
+        name = if record.is_a?(Class)
+          record.name
+        else
+          "this #{record.class.name}"
+        end
+
+        message = options.fetch(:message) { "not allowed to #{query} #{name}" }
       end
 
       super(message)

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -484,6 +484,16 @@ describe Pundit do
     it "raises an error with a invalid policy constructor" do
       expect { controller.authorize(wiki, :destroy?) }.to raise_error(Pundit::InvalidConstructorError)
     end
+
+    it "raises an error with class name when passed Class" do
+      expect { controller.authorize(Post, :index?) }
+        .to raise_error(Pundit::NotAuthorizedError, "not allowed to index? Post")
+    end
+
+    it "raises an error with class name when passed record" do
+      expect { controller.authorize(post, :destroy?) }
+        .to raise_error(Pundit::NotAuthorizedError, "not allowed to destroy? this Post")
+    end
   end
 
   describe "#skip_authorization" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,10 @@ class PostPolicy < Struct.new(:user, :post)
     true
   end
 
+  def index?
+    false
+  end
+
   def permitted_attributes
     if post.user == user
       %i[title votes]


### PR DESCRIPTION
In some cases you may want to authorize actions against a class not
instance of that class. If authorization fails when a class is passed to
authorize the error message is unhelpful. For example

    not allowed to index? Class

This PR checks if an instance or class was passed and provides more
informative error message in the case of a class. The error
message for an instance being passed remains the same.

For a concrete example of class being passed see jsonapi-authorization

https://github.com/venuu/jsonapi-authorization/blob/3251c6589d31bc931ee3a98c5c47e16eedd82b97/lib/jsonapi/authorization/default_pundit_authorizer.rb#L28-L31