### PR TITLE
docs: remove `protect_from_forgery` from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Include Pundit in your application controller:
 ``` ruby
 class ApplicationController < ActionController::Base
   include Pundit
-  protect_from_forgery
 end
 ```
 
@@ -493,7 +492,6 @@ method in every controller.
 
 ```ruby
 class ApplicationController < ActionController::Base
-  protect_from_forgery
   include Pundit
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized


### PR DESCRIPTION
Per https://github.com/rails/rails/commit/ec4a836919c021c0a5cf9ebeebb4db5e02104a55 on July 11, 2017, `protect_from_forgery` is now enabled by default in all Rails applications (5.2+). Thus, this change simplifies the `README` guide by removing the extraneous method call.

See this issue for additional discussion:
https://github.com/rails/rails/issues/29193

This will hopefully prevent someone from doing what I just did in a Rails 6 project:

1. Following the README to set up `pundit`, and on Step 1 was looking for the `protect_from_forgery` method call in `ApplicationController`
1. Noticed there was no call to this method, and had a momentary panic about the security of the application
1. Found the aforementioned commit and breathed a sigh of relief :)

**edit**
Adding a link to the Rails docs that confirms this behavior:

https://edgeguides.rubyonrails.org/configuring.html#configuring-action-controller