### PR TITLE
Support custom error messages in policies

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -33,7 +33,9 @@ module Pundit
         @policy = options[:policy]
         @reason = options[:reason]
 
-        message = options.fetch(:message) { "not allowed to #{query} this #{record.class}" }
+        message = options[:message] ||
+                  policy.try(:error_message) ||
+                  "not allowed to #{query} this #{record.class}"
       end
 
       super(message)

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -625,9 +625,49 @@ describe Pundit do
   end
 
   describe "Pundit::NotAuthorizedError" do
-    it "can be initialized with a string as message" do
-      error = Pundit::NotAuthorizedError.new("must be logged in")
-      expect(error.message).to eq "must be logged in"
+    let(:error) { Pundit::NotAuthorizedError.new(init_arg) }
+    let(:expected_message) { "lorem ipsum dolor" }
+
+    shared_examples "for error message" do
+      it "sets the appropriate error message" do
+        expect(error.message).to eq expected_message
+      end
+    end
+
+    context "initialized with a string" do
+      let(:init_arg) { expected_message }
+
+      include_examples "for error message"
+    end
+
+    context "initialized with a hash" do
+      let(:init_arg) do
+        { message: expected_message,
+          query: :show?,
+          record: post,
+          policy: Pundit.policy(user, post) }
+      end
+
+      context "containing :message" do
+        include_examples "for error message"
+      end
+
+      context "containing :policy with an #error_message" do
+        before do
+          init_arg.except!(:message)
+          init_arg[:policy].error_message = expected_message
+        end
+
+        include_examples "for error message"
+      end
+
+      context "containing :policy with no #error_message" do
+        before { init_arg.except!(:message) }
+
+        let(:expected_message) { "not allowed to show? this #{post.class}" }
+
+        include_examples "for error message"
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ require "active_support/core_ext"
 require "active_model/naming"
 require "action_controller/metal/strong_parameters"
 
-class PostPolicy < Struct.new(:user, :post)
+class PostPolicy < Struct.new(:user, :post, :error_message)
   class Scope < Struct.new(:user, :scope)
     def resolve
       scope.published


### PR DESCRIPTION
This commit allows policies to define the error messages set on `Pundit::NotAuthorizedError` exceptions when `#authorize` fails. The rationale is described in detail in GitHub issue #654, and summarized below.

Some queries can fail in multiple ways; for instance,

```ruby
class PostPolicy
  def update?
    if record.author != user
      ... # failure case 1
    elsif record.archived
      ... # failure case 2
    end

    true
  end
end
```

In their controllers, users might wish to handle different failure modes in different ways, but prior to this commit, there was only one way to tell the difference—namely, by raising errors inside the query method:

```ruby
def update?
  if record.author != user
    raise Pundit::NotAuthorizedError, 'You’re not the author!'
  elsif record.archived
    raise Pundit::NotAuthorizedError, 'This post is old news!'
  end

  true
end
```

This breaks the expectation that query methods should return booleans, which in turn breaks a pattern for using query methods in views:

```erb
<% if policy(@post).update? %>
  <%= link_to "Edit post", edit_post_path(@post) %>
<% end %>
```

973b63b added a `reason` option to the NotAuthorizedError initializer, but ultimately required the same approach of raising errors in queries.

---

This commit enables a cleaner method of passing a custom error message to exceptions from within policies, without violating the expectations of where exceptions are raised from.

```ruby
class PostPolicy
  attr_accessor :error_message

  def update?
    self.error_message = if record.author != user
                           'You’re not the author!'
                         elsif record.archived
                           'This post is old news!'
                         end

    error_message.nil?
  end
end
```