### PR TITLE
Use Rspec.describe rather than describe in specs

### DIFF
--- a/spec/policies/post_policy_spec.rb
+++ b/spec/policies/post_policy_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe PostPolicy do
+RSpec.describe PostPolicy do
   let(:user) { double }
   let(:own_post) { double(user: user) }
   let(:other_post) { double(user: double) }

--- a/spec/policy_finder_spec.rb
+++ b/spec/policy_finder_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Pundit::PolicyFinder do
+RSpec.describe Pundit::PolicyFinder do
   let(:user) { double }
   let(:post) { Post.new(user) }
   let(:comment) { CommentFourFiveSix.new }

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Pundit do
+RSpec.describe Pundit do
   let(:user) { double }
   let(:post) { Post.new(user) }
   let(:customer_post) { Customer::Post.new(user) }


### PR DESCRIPTION
This PR updates the pundit specs to use the namespaced `Rspec.describe` instead of `describe`. The generators already do this since [this PR](https://github.com/varvet/pundit/pull/313).