### PR TITLE
Remove mention of old Rails versions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,9 +695,8 @@ end
 
 ## Strong parameters
 
-In Rails 4 (or Rails 3.2 with the
-[strong_parameters](https://github.com/rails/strong_parameters) gem),
-mass-assignment protection is handled in the controller.  With Pundit you can
+In Rails,
+mass-assignment protection is handled in the controller. With Pundit you can
 control which attributes a user has access to update via your policies. You can
 set up a `permitted_attributes` method in your policy like this:
 


### PR DESCRIPTION
No need to mention old version of rails, it takes away from the message. Plus with it being now Rails 6 and changes being introduced in Rails 4, we can assume users already have the strong params feature.