### PR TITLE
Update an error message code example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,8 +569,7 @@ end
 Then you can get this error message in exception handler:
 ```ruby
 rescue_from Pundit::NotAuthorizedError do |e|
-  message = e.reason ? I18n.t("pundit.errors.#{e.reason}") : e.message
-  flash[:error] = message, scope: "pundit", default: :default
+  flash[:error] = I18n.t("errors.#{e.reason}", scope: "pundit", default: e.message)
   redirect_to(request.referrer || root_path)
 end
 ```


### PR DESCRIPTION
### the issue
I believe the existing example here has some copypasta from the previous example: https://github.com/varvet/pundit/blob/a09548c826b85ced18a2e54ec6195f68cb61dad2/README.md#L570-L576

specifically, the stuff after the comma is leftover from when this was an `I18n.t` (maybe) copied from https://github.com/varvet/pundit/blob/a09548c826b85ced18a2e54ec6195f68cb61dad2/README.md#L529

### the fix
a straightforward fix would just be deleting the stuff after the comma

e.g. 
```diff
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError do |e| 
     message = e.reason ? I18n.t("pundit.errors.#{e.reason}") : e.message 
-    flash[:error] = message, scope: "pundit", default: :default 
+    flash[:error] = message
     redirect_to(request.referrer || root_path) 
   end
   
```

But based on my understanding of the conversation on [PR #625][0], I _think_ my PR modifies the example to accomplish the intended effect

[0]:https://github.com/varvet/pundit/pull/625