### PR TITLE
Pundit::NotAuthorizedError default error message for namespaced policies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       env:
         - JRUBY_OPTS="--debug"
       jdk: openjdk8
-    - rvm: jruby-9.2.8.0
+    - rvm: jruby-9.2.15.0
       env:
         - JRUBY_OPTS="--debug"
 

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -33,7 +33,8 @@ module Pundit
         @policy = options[:policy]
         @reason = options[:reason]
 
-        message = options.fetch(:message) { "not allowed to #{query} this #{record.class}" }
+        model = record.is_a?(Array) ? record.last : record
+        message = options.fetch(:message) { "not allowed to #{query} this #{model.class}" }
       end
 
       super(message)

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -66,6 +66,12 @@ RSpec.describe Pundit do
       # rubocop:enable Style/MultilineBlockChain
     end
 
+    it "raises an error whose message contains the model class name when passed record with namespace" do
+      expect do
+        Pundit.authorize(user, [:project, comment], :destroy?)
+      end.to raise_error(Pundit::NotAuthorizedError, "not allowed to destroy? this Comment")
+    end
+
     it "raises an error with a invalid policy constructor" do
       expect do
         Pundit.authorize(user, wiki, :update?)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -163,6 +163,10 @@ module Project
       true
     end
 
+    def destroy?
+      false
+    end
+
     class Scope < Struct.new(:user, :scope)
       def resolve
         scope


### PR DESCRIPTION
`Pundit::NotAuthorizedError` provides the default error message like `"not allowed to destroy? this Array"` when namespaced policies are used.
This is because the record passed to `Pundit::NotAuthorizedError` is an Array.

This PR modifies the error message so that it provides clearer information on the model.
(e.g. `"not allowed to destroy? this Comment"` when `authorize([:project, comment], :destroy?)` is called).
