### PR TITLE
rescue-not_authorized_error-on-rspec

### DIFF
--- a/lib/pundit/rspec.rb
+++ b/lib/pundit/rspec.rb
@@ -10,6 +10,8 @@ module Pundit
         match_proc = lambda do |policy|
           @violating_permissions = permissions.find_all do |permission|
             !policy.new(user, record).public_send(permission)
+          rescue Pundit::NotAuthorizedError
+            true
           end
           @violating_permissions.empty?
         end
@@ -17,6 +19,8 @@ module Pundit
         match_when_negated_proc = lambda do |policy|
           @violating_permissions = permissions.find_all do |permission|
             policy.new(user, record).public_send(permission)
+          rescue Pundit::NotAuthorizedError
+            false
           end
           @violating_permissions.empty?
         end

--- a/spec/policies/post_policy_spec.rb
+++ b/spec/policies/post_policy_spec.rb
@@ -19,4 +19,10 @@ RSpec.describe PostPolicy do
       end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
     end
   end
+
+  permissions :create? do
+    it 'fails' do
+      should_not permit(user, own_post)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,10 @@ class PostPolicy < Struct.new(:user, :post)
     true
   end
 
+  def create?
+    raise Pundit::NotAuthorizedError, reason: 'user.paid_subscription_required'
+  end
+
   def permitted_attributes
     if post.user == user
       %i[title votes]


### PR DESCRIPTION
When apply [Multiple error messages per one policy action](https://github.com/varvet/pundit#multiple-error-messages-per-one-policy-action), 

`it { expect(subject).not_to permit(user, record) }` fails because it raise exception.
I think this matcher concerns only permit or not, so it should catch `Pundit::NotAuthorizedError`, and convert true/false.