### PR TITLE
Build against currently supported rubies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
   Exclude:
     - "lib/generators/**/templates/**/*"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,22 @@
 language: ruby
+dist: focal
 
 matrix:
   include:
     - name: "RuboCop lint on pre-installed Ruby version"
-      rvm: 2.5.3 # Pre-installed Ruby version
+      rvm: 2.7.1 # Pre-installed Ruby version
       before_install:
         - gem install bundler
       script: bundle exec rake rubocop # ONLY lint once, first
-    - rvm: 2.4.9
+    - rvm: 2.6.7
       before_script:
         - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
         - chmod +x ./cc-test-reporter
         - ./cc-test-reporter before-build
       after_script:
         - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-    - rvm: 2.5.7
-    - rvm: 2.6.5
-    - rvm: 2.7.0-preview3
-    - name: "jruby-9.1.8.0 on OpenJDK 8"
-      rvm: jruby-9.1.8.0
-      env:
-        - JRUBY_OPTS="--debug"
-      jdk: openjdk8
+    - rvm: 2.7.3
+    - rvm: 3.0.1
     - rvm: jruby-9.2.15.0
       env:
         - JRUBY_OPTS="--debug"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Dropped support for Ruby end-of-life versions: 2.1 and 2.2. (#604)
 - Dropped support for Ruby end-of-life versions: 2.3 (#633)
+- Dropped support for Ruby end-of-life versions: 2.4, 2.5 and JRuby 9.1 (#676)
 - Dropped support for RSpec 2 (#615)
 
 ## 2.1.0 (2019-08-14)


### PR DESCRIPTION
2.6 is the earliest currently supported Ruby version:

  https://www.ruby-lang.org/en/downloads/branches/