### PR TITLE
CI: Use JRuby 9.2.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       env:
         - JRUBY_OPTS="--debug"
       jdk: openjdk8
-    - rvm: jruby-9.2.15.0
+    - rvm: jruby-9.2.17.0
       env:
         - JRUBY_OPTS="--debug"
 


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.17.0**.

[JRuby 9.2.17.0 release blog post](https://www.jruby.org/2021/03/29/jruby-9-2-17-0.html)