### PR TITLE
Build against Truffleruby head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,6 @@ matrix:
     - rvm: jruby-9.2.15.0
       env:
         - JRUBY_OPTS="--debug"
-
+    - rvm: truffleruby-head
+  allow_failures:
+    - rvm: truffleruby-head


### PR DESCRIPTION
Truffleruby is a high-performance implementation of Ruby:

  https://github.com/oracle/truffleruby

We don't want to be responsible for supporting it, so it goes in the
allow-failures section.

Based on https://github.com/varvet/pundit/pull/662