### PR TITLE
Fix syntax issue in multiple error messages documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,11 +566,11 @@ class ProjectPolicy < ApplicationPolicy
 end
 ```
 
-Then you can get this error message in exception handler:
+Then you can get this error message in an exception handler:
 ```ruby
 rescue_from Pundit::NotAuthorizedError do |e|
-  message = e.reason ? I18n.t("pundit.errors.#{e.reason}") : e.message
-  flash[:error] = message, scope: "pundit", default: :default
+  message = e.reason ? I18n.t("pundit.errors.#{e.reason}", scope: "pundit", default: :default) : e.message
+  flash[:error] = message
   redirect_to(request.referrer || root_path)
 end
 ```


### PR DESCRIPTION
`flash[key]` does not accept a scope and default after the equals sign as the README indicates. Instead, these keyword args should be provided to the call to I18n.t on the line above.

I think this was just a bad copy-paste when this documentation was originally added.