### PR TITLE
Include policy name in NotAuthorizedError message

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ and the given record. It then infers from the action name, that it should call
 
 ``` ruby
 unless PostPolicy.new(current_user, @post).update?
-  raise Pundit::NotAuthorizedError, "not allowed to update? this #{@post.inspect}"
+  raise Pundit::NotAuthorizedError, "not allowed to update? with PostPolicy"
 end
 ```
 

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -33,7 +33,7 @@ module Pundit
         @policy = options[:policy]
         @reason = options[:reason]
 
-        message = options.fetch(:message) { "not allowed to #{query} this #{record.class}" }
+        message = options.fetch(:message) { "not allowed to #{query} with #{policy.class}" }
       end
 
       super(message)

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -51,14 +51,19 @@ RSpec.describe Pundit do
 
     it "works with anonymous class policies" do
       expect(Pundit.authorize(user, article_tag, :show?)).to be_truthy
-      expect { Pundit.authorize(user, article_tag, :destroy?) }.to raise_error(Pundit::NotAuthorizedError)
+      expect { Pundit.authorize(user, article_tag, :destroy?) }.to raise_error(Pundit::NotAuthorizedError, "not allowed to destroy? with ArticleTagOtherNamePolicy")
     end
 
-    it "raises an error with a query and action" do
+    it "works with an array of a symbol and plain model class" do
+      expect(Pundit.authorize(user, [:project, Comment], :update?)).to be_truthy
+      expect { Pundit.authorize(user, [:project, Comment], :destroy?) }.to raise_error(Pundit::NotAuthorizedError, "not allowed to destroy? with Project::CommentPolicy")
+    end
+
+    it "raises an error with a query and policy" do
       # rubocop:disable Style/MultilineBlockChain
       expect do
         Pundit.authorize(user, post, :destroy?)
-      end.to raise_error(Pundit::NotAuthorizedError, "not allowed to destroy? this Post") do |error|
+      end.to raise_error(Pundit::NotAuthorizedError, "not allowed to destroy? with PostPolicy") do |error|
         expect(error.query).to eq :destroy?
         expect(error.record).to eq post
         expect(error.policy).to eq Pundit.policy(user, post)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -163,6 +163,10 @@ module Project
       true
     end
 
+    def destroy?
+      false
+    end
+
     class Scope < Struct.new(:user, :scope)
       def resolve
         scope


### PR DESCRIPTION
record is sometimes an Object, sometimes a Class and sometimes an Array. Use the policy instead in the error message.

e.g.
```
authorize(Post.first)
before: not allowed to destroy? this Post
after : not allowed to destroy? with PostPolicy
```

```
authorize([:project, Post.first])
before: not allowed to destroy? this Array
after : not allowed to destroy? with Project::PostPolicy
```

This is a slightly different solution to the problem raised by #670. This may not the right solution but it was easy to create without refactoring what 'record' means when it is an Array.

Please let me know if there is anything I can do to help this go through. 