### PR TITLE
Policy spec template fix for RSpec/LeadingSubject

### DIFF
--- a/lib/generators/rspec/templates/policy_spec.rb
+++ b/lib/generators/rspec/templates/policy_spec.rb
@@ -1,9 +1,9 @@
 require '<%= File.exists?('spec/rails_helper.rb') ? 'rails_helper' : 'spec_helper' %>'
 
 RSpec.describe <%= class_name %>Policy, type: :policy do
-  let(:user) { User.new }
-
   subject { described_class }
+
+  let(:user) { User.new }
 
   permissions ".scope" do
     pending "add some examples to (or delete) #{__FILE__}"


### PR DESCRIPTION
Policy spec template fix for RSpec/LeadingSubject - https://www.rubydoc.info/gems/rubocop-rspec/1.7.0/RuboCop/Cop/RSpec/LeadingSubject.