### PR TITLE
Policy spec template fix for Style/StringLiterals

### DIFF
--- a/lib/generators/rspec/templates/policy_spec.rb
+++ b/lib/generators/rspec/templates/policy_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe <%= class_name %>Policy, type: :policy do
 
   subject { described_class }
 
-  permissions ".scope" do
+  permissions '.scope' do
     pending "add some examples to (or delete) #{__FILE__}"
   end
 


### PR DESCRIPTION
Update for the default setting of Style/StringLiterals - https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StringLiterals.