### PR TITLE
Revert "Merge pull request #625 from holyketzer/custom-messages"

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,46 +544,6 @@ en:
 Of course, this is just an example. Pundit is agnostic as to how you implement
 your error messaging.
 
-## Multiple error messages per one policy action
-
-If there are multiple reasons that authorization can be denied, you can show different messages by raising exceptions in your policy:
-
-In your policy class raise `Pundit::NotAuthorizedError` with custom error message or I18n key in `reason` argument:
-
-```ruby
-class ProjectPolicy < ApplicationPolicy
-  def create?
-    if user.has_paid_subscription?
-      if user.project_limit_reached?
-        raise Pundit::NotAuthorizedError, reason: 'user.project_limit_reached'
-      else
-        true
-      end
-    else
-      raise Pundit::NotAuthorizedError, reason: 'user.paid_subscription_required'
-    end
-  end
-end
-```
-
-Then you can get this error message in exception handler:
-```ruby
-rescue_from Pundit::NotAuthorizedError do |e|
-  message = e.reason ? I18n.t("pundit.errors.#{e.reason}") : e.message
-  flash[:error] = message, scope: "pundit", default: :default
-  redirect_to(request.referrer || root_path)
-end
-```
-
-```yaml
-en:
-  pundit:
-    errors:
-      user:
-        paid_subscription_required: 'Paid subscription is required'
-        project_limit_reached: 'Project limit is reached'
-```
-
 ## Manually retrieving policies and scopes
 
 Sometimes you want to retrieve a policy for a record outside the controller or

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -22,7 +22,7 @@ module Pundit
 
   # Error that will be raised when authorization has failed
   class NotAuthorizedError < Error
-    attr_reader :query, :record, :policy, :reason
+    attr_reader :query, :record, :policy
 
     def initialize(options = {})
       if options.is_a? String
@@ -31,7 +31,6 @@ module Pundit
         @query  = options[:query]
         @record = options[:record]
         @policy = options[:policy]
-        @reason = options[:reason]
 
         message = options.fetch(:message) { "not allowed to #{query} this #{record.class}" }
       end


### PR DESCRIPTION
Reverting this because it's blocking us from making a new release, see: https://github.com/varvet/pundit/issues/656#issuecomment-895827605

Additionally, me and @dgmstuart have backtracked a bit and believe that _in case_ you'd like to use a solution similar to this then you should probably use specialized error classes instead, something similar to this:

```ruby
UserProjectLimitReachedError = Class.new(Pundit::NotAuthorizedError)

def create?
  raise UserProjectLimitReachedError unless user.has_paid_subscription?
end
```

All that said, I believe that the reasoning in https://github.com/varvet/pundit/issues/654 is sound, and so query methods should strive towards returning truthy/falsy as opposed to raising errors to deal with custom error messages.