### PR TITLE
Release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 2.1.1 (2021-08-13)
+
+Friday 13th-release!
+
+Careful! The bugfix below (#626) could break existing code. If you rely on the
+return value for `authorize` and namespaced policies you might need to do some
+changes.
+
 ### Fixed
 
 - `.authorize` and `#authorize` return the instance, even for namespaced

--- a/lib/pundit/version.rb
+++ b/lib/pundit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pundit
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end


### PR DESCRIPTION
Friday 13th-release!

Careful! The bugfix in (#626) could break existing code. If you rely on the
return value for `authorize` and namespaced policies you might need to do some
changes.

Closes #656.
