### PR TITLE
Pass record correctly when using `policy_class`

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -67,7 +67,7 @@ module Pundit
     # @raise [NotAuthorizedError] if the given query method returned false
     # @return [Object] Always returns the passed object record
     def authorize(user, record, query, policy_class: nil)
-      policy = policy_class ? policy_class.new(user, record) : policy!(user, record)
+      policy = policy_class ? policy_class.new(user, pundit_model(record)) : policy!(user, record)
 
       raise NotAuthorizedError, query: query, record: record, policy: policy unless policy.public_send(query)
 
@@ -218,11 +218,12 @@ module Pundit
 
     @_pundit_policy_authorized = true
 
-    policy = policy_class ? policy_class.new(pundit_user, record) : policy(record)
+    actual_record = record.is_a?(Array) ? record.last : record
+    policy = policy_class ? policy_class.new(pundit_user, actual_record) : policy(record)
 
     raise NotAuthorizedError, query: query, record: record, policy: policy unless policy.public_send(query)
 
-    record.is_a?(Array) ? record.last : record
+    actual_record
   end
 
   # Allow this action not to perform authorization.

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -49,6 +49,11 @@ RSpec.describe Pundit do
       expect(Pundit.authorize(user, post, :create?, policy_class: PublicationPolicy)).to be_truthy
     end
 
+    it "can be given a different policy class using namespaces" do
+      expect(PublicationPolicy).to receive(:new).with(user, comment).and_call_original
+      expect(Pundit.authorize(user, [:project, comment], :create?, policy_class: PublicationPolicy)).to be_truthy
+    end
+
     it "works with anonymous class policies" do
       expect(Pundit.authorize(user, article_tag, :show?)).to be_truthy
       expect { Pundit.authorize(user, article_tag, :destroy?) }.to raise_error(Pundit::NotAuthorizedError)
@@ -456,6 +461,11 @@ RSpec.describe Pundit do
 
     it "can be given a different policy class" do
       expect(controller.authorize(post, :create?, policy_class: PublicationPolicy)).to be_truthy
+    end
+
+    it "can be given a different policy class using namespaces" do
+      expect(PublicationPolicy).to receive(:new).with(user, comment).and_call_original
+      expect(controller.authorize([:project, comment], :create?, policy_class: PublicationPolicy)).to eql(comment)
     end
 
     it "works with anonymous class policies" do


### PR DESCRIPTION
Fixes https://github.com/varvet/pundit/issues/689

This patch makes `authorize` remove namespaces before passing them to the constructor of `policy_class`, if defined.

Added tests accordingly.