### PR TITLE
Strip namespace when using `policy_class`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Using `policy_class` and a namespaced record now passes only the record when instantiating the policy. (#697, #689, #694, #666)
+
 ## 2.1.1 (2021-08-13)
 
 Friday 13th-release!

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -67,7 +67,7 @@ module Pundit
     # @raise [NotAuthorizedError] if the given query method returned false
     # @return [Object] Always returns the passed object record
     def authorize(user, record, query, policy_class: nil)
-      policy = policy_class ? policy_class.new(user, record) : policy!(user, record)
+      policy = policy_class ? policy_class.new(user, pundit_model(record)) : policy!(user, record)
 
       raise NotAuthorizedError, query: query, record: record, policy: policy unless policy.public_send(query)
 
@@ -218,11 +218,12 @@ module Pundit
 
     @_pundit_policy_authorized = true
 
-    policy = policy_class ? policy_class.new(pundit_user, record) : policy(record)
+    actual_record = record.is_a?(Array) ? record.last : record
+    policy = policy_class ? policy_class.new(pundit_user, actual_record) : policy(record)
 
     raise NotAuthorizedError, query: query, record: record, policy: policy unless policy.public_send(query)
 
-    record.is_a?(Array) ? record.last : record
+    actual_record
   end
 
   # Allow this action not to perform authorization.

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -71,6 +71,18 @@ RSpec.describe Pundit do
       # rubocop:enable Style/MultilineBlockChain
     end
 
+    it "raises an error with a the record, query and action when the record is namespaced" do
+      # rubocop:disable Style/MultilineBlockChain
+      expect do
+        Pundit.authorize(user, [:project, :admin, comment], :destroy?)
+      end.to raise_error(Pundit::NotAuthorizedError, "not allowed to destroy? this Comment") do |error|
+        expect(error.query).to eq :destroy?
+        expect(error.record).to eq comment
+        expect(error.policy).to eq Pundit.policy(user, [:project, :admin, comment])
+      end
+      # rubocop:enable Style/MultilineBlockChain
+    end
+
     it "raises an error with a invalid policy constructor" do
       expect do
         Pundit.authorize(user, wiki, :update?)

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -49,6 +49,11 @@ RSpec.describe Pundit do
       expect(Pundit.authorize(user, post, :create?, policy_class: PublicationPolicy)).to be_truthy
     end
 
+    it "can be given a different policy class using namespaces" do
+      expect(PublicationPolicy).to receive(:new).with(user, comment).and_call_original
+      expect(Pundit.authorize(user, [:project, comment], :create?, policy_class: PublicationPolicy)).to be_truthy
+    end
+
     it "works with anonymous class policies" do
       expect(Pundit.authorize(user, article_tag, :show?)).to be_truthy
       expect { Pundit.authorize(user, article_tag, :destroy?) }.to raise_error(Pundit::NotAuthorizedError)
@@ -456,6 +461,11 @@ RSpec.describe Pundit do
 
     it "can be given a different policy class" do
       expect(controller.authorize(post, :create?, policy_class: PublicationPolicy)).to be_truthy
+    end
+
+    it "can be given a different policy class using namespaces" do
+      expect(PublicationPolicy).to receive(:new).with(user, comment).and_call_original
+      expect(controller.authorize([:project, comment], :create?, policy_class: PublicationPolicy)).to eql(comment)
     end
 
     it "works with anonymous class policies" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -185,6 +185,10 @@ module Project
       def update?
         true
       end
+
+      def destroy?
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #689
Closes #694
Closes #666

Using `policy_class` and namespacing are two different ways of doing the same thing (specifying which policy to use). When both are given, we ignore the namespacing and rely on policy class since it's more specific — when we do so, we need to strip the namespace when passing the record to the policy class.

This is a refactor of #694.

TODO:
- [x] Update the changelog.
