### PR TITLE
Use `scope.none` by default in generated templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Using `policy_class` and a namespaced record now passes only the record when instantiating the policy. (#697, #689, #694, #666)
 
+### Changed
+
+- Use `scope.none` by default in `ApplicationPolicy` scope. (#711)
+
 ### Deprecated
 
 - Deprecate `include Pundit` in favor of `include Pundit::Authorization` (#621)

--- a/lib/generators/pundit/install/templates/application_policy.rb
+++ b/lib/generators/pundit/install/templates/application_policy.rb
@@ -43,7 +43,7 @@ class ApplicationPolicy
     end
 
     def resolve
-      scope.all
+      scope.none
     end
 
     private

--- a/lib/generators/pundit/policy/templates/policy.rb
+++ b/lib/generators/pundit/policy/templates/policy.rb
@@ -2,7 +2,7 @@
 class <%= class_name %>Policy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope.all
+      raise NotImplementedError, 'You need to implement this before using the scope'
     end
   end
 end


### PR DESCRIPTION
Hi! 👋🏼 👋🏼 

First time contributing here

I'm not sure if this change:
- should be considered a breaking change
- the new behavior should be documented somewhere
- every supported ORM responds to `none`

Let me know what do you think

---

A01:2021-Broken Access Control is the category with the most serious web
application security risk.

Using `scope.all` in templates violates the principle of least privilege
or deny by default, where access should only be granted for particular
capabilities, roles, or users.

This change improves the security of default templates

Ref: https://owasp.org/Top10/A01_2021-Broken_Access_Control/