### PR TITLE
Remove meaningless extra stripping of heredoc

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -55,7 +55,7 @@ module Pundit
   class NotDefinedError < Error; end
 
   def self.included(base)
-    ActiveSupport::Deprecation.warn <<~WARNING.strip_heredoc
+    ActiveSupport::Deprecation.warn <<~WARNING
       'include Pundit' is deprecated. Please use 'include Pundit::Authorization' instead.
     WARNING
     base.include Authorization


### PR DESCRIPTION
Squiggly heredoc is already stripped, so the `strip_heredoc` does not change the string.

Furthermore `strip_heredoc` is not available in early rails application setup, so we shouldn't use it here without `require 'active_support/core_ext/string/strip`