### PR TITLE
Track why authorization was skipped, for later use in verify_authorized

### DIFF
--- a/lib/pundit/authorization.rb
+++ b/lib/pundit/authorization.rb
@@ -70,9 +70,10 @@ module Pundit
     # Allow this action not to perform authorization.
     #
     # @see https://github.com/varvet/pundit#ensuring-policies-and-scopes-are-used
+    # @param reason [Symbol, String] optional reason why the authorization was skipped
     # @return [void]
-    def skip_authorization
-      @_pundit_policy_authorized = :skipped
+    def skip_authorization(reason = :skipped)
+      @_pundit_policy_authorized = reason
     end
 
     # Allow this action not to perform policy scoping.

--- a/spec/authorization_spec.rb
+++ b/spec/authorization_spec.rb
@@ -123,6 +123,11 @@ describe Pundit::Authorization do
       controller.skip_authorization
       expect { controller.verify_authorized }.not_to raise_error
     end
+
+    it "tracks why authorization verification was disabled" do
+      controller.skip_authorization(:api_key)
+      expect(controller.instance_variable_get(:@_pundit_policy_authorized)).to be == :api_key
+    end
   end
 
   describe "#skip_policy_scope" do


### PR DESCRIPTION
For our use case, it would be helpful to track _why_ authorization was skipped, so that we can propagate that reason through to e.g. logs or custom metrics. This PR extends `skip_authorization` to allow specifying a reason, e.g. `skip_authorization :api_key`, which we can then handle in a custom `verify_authorized` method.

Hopefully this strikes a balance between adding a useful capability, versus adding a bunch of extra variables and methods that no one will use.

e.g.
```ruby
class TestController < ActionController::Base
  def index
    skip_authorization :api_key
    ...
  end

  after_action def verify_authorized
   logger.info("Authorization skipped, reason = #{@_pundit_policy_authorized}") if @_pundit_policy_authorized.is_a?(Symbol)
  end
end
```