### PR TITLE
Use redirect_back in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ class ApplicationController < ActionController::Base
 
   def user_not_authorized
     flash[:alert] = "You are not authorized to perform this action."
-    redirect_to(request.referrer || root_path)
+    redirect_back(fallback_location: root_path)
   end
 end
 ```
@@ -541,7 +541,7 @@ class ApplicationController < ActionController::Base
    policy_name = exception.policy.class.to_s.underscore
 
    flash[:error] = t "#{policy_name}.#{exception.query}", scope: "pundit", default: :default
-   redirect_to(request.referrer || root_path)
+   redirect_back(fallback_url: root_path)
  end
 end
 ```


### PR DESCRIPTION
Inspired by https://github.com/varvet/pundit/issues/727
Thanks to @joemasilotti 

Since Rails 5 (?) we have a more idiomatic way to redirect back to the previous page.

As it turns out this is pretty much just syntactic sugar for the previous implementation, but it feels like the more correct way to do it these days:(https://github.com/rails/rails/blob/de53ba56cab69fb9707785a397a59ac4aaee9d6f/actionpack/lib/action_controller/metal/redirecting.rb#L95-L128)