### PR TITLE
Pass block as argument of describe call.

### DIFF
--- a/lib/pundit/rspec.rb
+++ b/lib/pundit/rspec.rb
@@ -55,7 +55,7 @@ module Pundit
 
     module DSL
       def permissions(*list, &block)
-        describe(list.to_sentence, permissions: list, caller: caller) { instance_eval(&block) }
+        describe(list.to_sentence, permissions: list, caller: caller, &block)
       end
     end
 


### PR DESCRIPTION
Hey there,

we recently running into this issue while trying to extend the permissions example group that the block cannot be extended as expected (eg. using module_eval in combination with instance_eval).

It also shortens the code. :)