### PR TITLE
Add support for rubocop-rspec syntax extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,6 +802,16 @@ An alternative approach to Pundit policy specs is scoping them to a user context
 
 Pundit does not provide a DSL for testing scopes. Just test it like a regular Ruby class!
 
+### Linting with RuboCop RSpec
+
+When you lint your RSpec spec files with `rubocop-rspec`, it will fail to properly detect RSpec constructs that Pundit defines, `permissions`.
+Make sure to use `rubocop-rspec` 2.0 or newer and add the following to your `.rubocop.yml`:
+
+```yaml
+inherit_gem:
+  pundit: config/rubocop-rspec.yml
+```
+
 # External Resources
 
 - [RailsApps Example Application: Pundit and Devise](https://github.com/RailsApps/rails-devise-pundit)

--- a/config/rubocop-rspec.yml
+++ b/config/rubocop-rspec.yml
@@ -1,0 +1,5 @@
+RSpec:
+  Language:
+    ExampleGroups:
+      Regular:
+        - permissions


### PR DESCRIPTION
Hi, Thank you for Great Gem.

fix #691 

## Example

Gemfile
```ruby
# frozen_string_literal: true

source 'https://rubygems.org'

gem 'pundit', path: '../pundit'
gem 'rubocop'
gem 'rubocop-rspec'
```

.rubocop.yml
```yml
AllCops:
  NewCops: enable

require:
  - rubocop-rspec

inherit_gem:
  pundit: config/rubocop-rspec.yml
```

spec/policies/some_policy_spec.rb
```ruby
# frozen_string_literal: true

RSpec.describe SomePolicy do
  permissions :update?, :edit? do
    'wowwow'
  end
end
```

Before

```
bundle exec rubocop
Inspecting 2 files
.C

Offenses:

spec/policies/some_policy_spec.rb:3:1: C: [Correctable] RSpec/EmptyExampleGroup: Empty example group detected.
RSpec.describe SomePolicy do
^^^^^^^^^^^^^^^^^^^^^^^^^

2 files inspected, 1 offense detected, 1 offense autocorrectable
```

After
```
bundle exec rubocop
Inspecting 2 files
.C

Offenses:

spec/policies/some_policy_spec.rb:4:3: C: [Correctable] RSpec/EmptyExampleGroup: Empty example group detected.
  permissions :update?, :edit? do
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

2 files inspected, 1 offense detected, 1 offense autocorrectable
```

See also:
https://github.com/palkan/action_policy/pull/138
https://github.com/test-prof/test-prof/pull/199


