### PR TITLE
use File.exist? instead of File.exists?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
     - rvm: 2.7.3
     - rvm: 3.0.1
     - rvm: 3.1.0
+    - rvm: 3.2.0
     - rvm: jruby-9.2.17.0
       env:
         - JRUBY_OPTS="--debug"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - rvm: 3.0.1
     - rvm: 3.1.0
     - rvm: 3.2.0
-    - rvm: jruby-9.2.17.0
+    - rvm: jruby-9.3.10.0
       env:
         - JRUBY_OPTS="--debug"
     - rvm: truffleruby-head

--- a/lib/generators/rspec/templates/policy_spec.rb
+++ b/lib/generators/rspec/templates/policy_spec.rb
@@ -1,4 +1,4 @@
-require '<%= File.exists?('spec/rails_helper.rb') ? 'rails_helper' : 'spec_helper' %>'
+require '<%= File.exist?('spec/rails_helper.rb') ? 'rails_helper' : 'spec_helper' %>'
 
 RSpec.describe <%= class_name %>Policy, type: :policy do
   let(:user) { User.new }


### PR DESCRIPTION
File.exists? is deprecated in Ruby > 3.2. 
This causes an error when running the policy generator.