### PR TITLE
Fix CI: Bump JRuby version to 9.3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - rvm: 2.7.3
     - rvm: 3.0.1
     - rvm: 3.1.0
-    - rvm: jruby-9.2.17.0
+    - rvm: jruby-9.3.10.0
       env:
         - JRUBY_OPTS="--debug"
     - rvm: truffleruby-head


### PR DESCRIPTION
For recent PRs the pipeline fails because the JRuby version fails to install `bundler`. 

I recommend using JRuby 9.3.x as a test version because this is the matching version to the minimum tested ruby version 2.6.x.

> JRuby 9.3.10.0 is our point release of our Ruby 2.6.x support. Please check out our release notes for more information.
> https://www.jruby.org/download