### PR TITLE
feat: Add customizable permit description

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,6 +795,14 @@ describe PostPolicy do
 end
 ```
 
+You can customize the description used for the `permit` matcher:
+
+``` ruby
+Pundit::RSpec::Matchers.description do
+  "permit the user"
+end
+```
+
 An alternative approach to Pundit policy specs is scoping them to a user context as outlined in this
 [excellent post](http://thunderboltlabs.com/blog/2013/03/27/testing-pundit-policies-with-rspec/) and implemented in the third party [pundit-matchers](https://github.com/chrisalley/pundit-matchers) gem.
 

--- a/lib/pundit/rspec.rb
+++ b/lib/pundit/rspec.rb
@@ -5,6 +5,10 @@ module Pundit
     module Matchers
       extend ::RSpec::Matchers::DSL
 
+      def self.description(&block)
+        @description = block.call
+      end
+
       # rubocop:disable Metrics/BlockLength
       matcher :permit do |user, record|
         match_proc = lambda do |policy|
@@ -31,6 +35,14 @@ module Pundit
           was_were = @violating_permissions.count > 1 ? "were" : "was"
           "Expected #{policy} not to grant #{permissions.to_sentence} on " \
           "#{record} but #{@violating_permissions.to_sentence} #{was_were} granted"
+        end
+
+        description do
+          if Pundit::RSpec::Matchers.instance_variable_defined?(:@description)
+            Pundit::RSpec::Matchers.instance_variable_get(:@description)
+          else
+            super()
+          end
         end
 
         if respond_to?(:match_when_negated)


### PR DESCRIPTION
In this common example, the default description is noisy and doesn't add any information:

🔈 Default output:

```
ActionItemPolicy
  show?
    grants access to a customer manager member
    when the user is a customer operations member
      when there is no relationship to the action item
        is expected not to permit #<User id: 2, email_address: "test+user2@x-b-e.com", mobile_number: nil, created_at: "2023-02-18 14:3...ation_event_at: nil, release_note_feed_token: nil, opt_out_of_check_in_request_notifications: false> and #<ActionItem id: 2, title: "Fix all the things!", responsible_organization_type: "Customer", responsi...quires_xbe_feature: false, meeting_id: nil, created_by_id: nil, project_id: nil, root_cause_id: nil>
```

This PR enables you to customize the description.

``` ruby
Pundit::RSpec::Matchers.description do
  "permit the user"
end
```

💆 Customized output:

```
ActionItemPolicy
  show?
    grants access to a customer manager member
    when the user is a customer operations member
      when there is no relationship to the action item
        is expected not to permit the user
```

- closes #759 