### PR TITLE
Remove deprecated usage of ActiveSupport::Deprecation singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Use `Kernel.warn` instead of `ActiveSupport::Deprecation.warn` for deprecations (#764)
 - Policy generator now works on Ruby 3.2 (#754)
 
 ## 2.3.0 (2022-12-19)

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -55,7 +55,7 @@ module Pundit
   class NotDefinedError < Error; end
 
   def self.included(base)
-    ActiveSupport::Deprecation.warn <<~WARNING
+    warn <<~WARNING
       'include Pundit' is deprecated. Please use 'include Pundit::Authorization' instead.
     WARNING
     base.include Authorization

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -55,8 +55,10 @@ module Pundit
   class NotDefinedError < Error; end
 
   def self.included(base)
+    location = caller_locations(1, 1).first
     warn <<~WARNING
       'include Pundit' is deprecated. Please use 'include Pundit::Authorization' instead.
+       (called from #{location.label} at #{location.path}:#{location.lineno})
     WARNING
     base.include Authorization
   end

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -399,9 +399,9 @@ RSpec.describe Pundit do
     it "includes Authorization module" do
       klass = Class.new
 
-      ActiveSupport::Deprecation.silence do
+      expect do
         klass.include Pundit
-      end
+      end.to output.to_stderr
 
       expect(klass).to include Pundit::Authorization
     end

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -408,13 +408,9 @@ RSpec.describe Pundit do
 
     it "warns about deprecation" do
       klass = Class.new
-      allow(ActiveSupport::Deprecation).to receive(:warn)
-
-      ActiveSupport::Deprecation.silence do
+      expect do
         klass.include Pundit
-      end
-
-      expect(ActiveSupport::Deprecation).to have_received(:warn).with start_with("'include Pundit' is deprecated")
+      end.to output(a_string_starting_with("'include Pundit' is deprecated")).to_stderr
     end
   end
 


### PR DESCRIPTION
Rails 7.1 will deprecate usage of the `ActiveSupport::Deprecation` singleton (calling `warn`, `silence`, etc. directly on it) (see https://github.com/rails/rails/pull/47354).

This remove the only use of it. I usually replace such usage by an instance of `ActiveSupport::Deprecation`, but in this case since it was only used once, and the caller information isn't as important as usual (it's pretty easy to find a call to `include Pundit`), I simply used a Ruby warning with `warn`. There's another difference in that the message isn't prepended by "DEPRECATION WARNING: ", let me know if that matters a lot.