### PR TITLE
Add the keyword args patch to pass args to the permission methods.

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -73,7 +73,7 @@ module Pundit
     # @param cache [#[], #[]=] a Hash-like object to cache the found policy instance in
     # @raise [NotAuthorizedError] if the given query method returned false
     # @return [Object] Always returns the passed object record
-    def authorize(user, possibly_namespaced_record, query, policy_class: nil, cache: {})
+    def authorize(user, possibly_namespaced_record, query, policy_class: nil, cache: {}, **kwargs)
       record = pundit_model(possibly_namespaced_record)
       policy = if policy_class
         policy_class.new(user, record)
@@ -81,7 +81,7 @@ module Pundit
         cache[possibly_namespaced_record] ||= policy!(user, possibly_namespaced_record)
       end
 
-      raise NotAuthorizedError, query: query, record: record, policy: policy unless policy.public_send(query)
+      raise NotAuthorizedError, query: query, record: record, policy: policy unless policy.public_send(query, **kwargs)
 
       record
     end

--- a/lib/pundit/authorization.rb
+++ b/lib/pundit/authorization.rb
@@ -59,12 +59,12 @@ module Pundit
     # @param policy_class [Class] the policy class we want to force use of
     # @raise [NotAuthorizedError] if the given query method returned false
     # @return [Object] Always returns the passed object record
-    def authorize(record, query = nil, policy_class: nil)
+    def authorize(record, query = nil, policy_class: nil, **kwargs)
       query ||= "#{action_name}?"
 
       @_pundit_policy_authorized = true
 
-      Pundit.authorize(pundit_user, record, query, policy_class: policy_class, cache: policies)
+      Pundit.authorize(pundit_user, record, query, policy_class: policy_class, cache: policies, **kwargs)
     end
 
     # Allow this action not to perform authorization.


### PR DESCRIPTION
I don't think this is a good pattern, but making it work is easier than rewriting all the bad code in our app. Going to add deprecations sometime soon so we can clean it up in a controlled manner.