### PR TITLE
Do not use NotImplementedError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-Nothing.
+- Policy generator uses `NoMethodError` to indicate `#resolve` is not implemented (#776)
 
 ## 2.3.1 (2023-07-17)
 

--- a/lib/generators/pundit/install/templates/application_policy.rb
+++ b/lib/generators/pundit/install/templates/application_policy.rb
@@ -43,7 +43,7 @@ class ApplicationPolicy
     end
 
     def resolve
-      raise NotImplementedError, "You must define #resolve in #{self.class}"
+      raise NoMethodError, "You must define #resolve in #{self.class}"
     end
 
     private

--- a/spec/generators_spec.rb
+++ b/spec/generators_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "generators" do
       describe "#resolve" do
         it "raises a descriptive error" do
           scope = WidgetPolicy::Scope.new(double("User"), double("User.all"))
-          expect { scope.resolve }.to raise_error(NotImplementedError, /WidgetPolicy::Scope/)
+          expect { scope.resolve }.to raise_error(NoMethodError, /WidgetPolicy::Scope/)
         end
       end
     end


### PR DESCRIPTION
Instead use `NoMethodError` as to indicate that the method should be defined in the class

Closes #775

## To do

- [x] I have read the [contributing guidelines](https://github.com/varvet/pundit/contribute).
- [x] I have added relevant tests.
- [x] I have adjusted relevant documentation.
- [x] I have made sure the individual commits are meaningful.
- [x] I have added relevant lines to the CHANGELOG.

PS: Thank you for contributing to Pundit ❤️
