### PR TITLE
Adjust GH actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         ruby-version:
           - '3.0'
           - '3.1'
-          - 'jruby-9.3.10'
+          - 'jruby-9.3.10' # oldest supported jruby
           - 'jruby'
         include: # HEAD-versions
           - ruby-version: 'head'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.allow-failure || false }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         ruby-version:
           - '3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+# https://github.com/ruby/psych/issues/655
+gem "psych", "!= 5.1.1", platforms: %i[jruby]


### PR DESCRIPTION
I recently made a change to allow for running the workflow manually on `main`, which I did in order to double-check if a certain failure was due to a PR or if it's also failing on main.

I've since disabled bypassing branch protections on `main`, so now there's a PR for this change.

And finally, I noticed that if a required job (e.g. `jruby`) fails then our tests fail fast which we don't want. We still want all tests to run, but `matrix-test` should be considered failed if any of the required ruby versions fail.
