### PR TITLE
Prevent usage of `only:` filter for limiting `after_action` filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,8 +362,15 @@ authorize individual instances.
 ``` ruby
 class ApplicationController < ActionController::Base
   include Pundit::Authorization
-  after_action :verify_authorized, except: :index
-  after_action :verify_policy_scoped, only: :index
+  after_action :verify_pundit_authorization
+
+  def verify_pundit_authorization
+    if action_name == "index"
+      verify_policy_scoped
+    else
+      verify_authorized
+    end
+  end
 end
 ```
 


### PR DESCRIPTION
Starting with Rails 7.1 a new security check has been added; it checks whether referenced actions do exist for a given filter. (https://guides.rubyonrails.org/configuring.html#config-action-controller-raise-on-missing-callback-actions)

Because we cannot guaranty that all controller have a index method, the given example in the readme of Pundit for a `after_action` checking the usage of the lib will raise exceptions in a default rails application.  

This Pull requests changes the code example to use just a normal if statement to check the given `action_name`.