### PR TITLE
Qualify the `Scope` class name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update `ApplicationPolicy`` generator to qualify the `Scope` class name (#792)
+
 - Policy generator uses `NoMethodError` to indicate `#resolve` is not implemented (#776)
 
 ## 2.3.1 (2023-07-17)

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ generator, or create your own base class to inherit from:
 
 ``` ruby
 class PostPolicy < ApplicationPolicy
-  class Scope < Scope
+  class Scope < ApplicationPolicy::Scope
     def resolve
       if user.admin?
         scope.all
@@ -476,7 +476,7 @@ example, associations which might be `nil`.
 
 ```ruby
 class NilClassPolicy < ApplicationPolicy
-  class Scope < Scope
+  class Scope < ApplicationPolicy::Scope
     def resolve
       raise Pundit::NotDefinedError, "Cannot scope NilClass"
     end

--- a/lib/generators/pundit/policy/templates/policy.rb
+++ b/lib/generators/pundit/policy/templates/policy.rb
@@ -1,6 +1,12 @@
 <% module_namespacing do -%>
 class <%= class_name %>Policy < ApplicationPolicy
-  class Scope < Scope
+  # NOTE: Up to Pundit v2.3.1, the inheritance was declared as
+  # `Scope < Scope` rather than `Scope < ApplicationPolicy::Scope`.
+  # In most cases the behavior will be identical, but if updating existing
+  # code, beware of possible changes to the ancestors:
+  # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
+
+  class Scope < ApplicationPolicy::Scope
     # NOTE: Be explicit about which records you allow access to!
     # def resolve
     #   scope.all


### PR DESCRIPTION
I'd like to propose this small change to the generator, and the corresponding examples in the README. However, I'm very new to Pundit so I'm seeking input from others with more experience.

When using the generator, it results in a `Scope < Scope` inheritance, equivalent to `Scope < ApplicationPolicy::Scope`.

This may be a matter of personal taste, but I find that having a class inheriting from another with (visually) the same name is jarring, and reduces readability, since it requires reading the surrounding context.

Additionally, this causes complications with typing system. For example, if using Sorbet:

```
app/policies/list_policy.rb:37: Circular dependency: ListPolicy::Scope is a parent of itself https://srb.help/5011
    37 |  class Scope < Scope
```
(although it can be argued that this is a bug/limitation of Sorbet).

Looking forward to hearing some feedback.
