### PR TITLE
Add scaffold generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,21 @@ Use the supplied generator to generate policies:
 ``` sh
 rails g pundit:policy post
 ```
+The scaffold command:
+```sh
+rails g scaffold Post
+```
+will also generate a policy and a scaffolded controller with Pundit's authorization method calls for actions.
+```sh
+...
+      invoke  scaffold_controller
+      create    app/controllers/posts_controller.rb
+...
+      invoke  policy
+      create    app/policies/post_policy.rb
+      invoke    rspec
+      create      spec/policies/post_policy_spec.rb
+```
 
 ## Closed systems
 

--- a/lib/generators/pundit/scaffold/scaffold_generator.rb
+++ b/lib/generators/pundit/scaffold/scaffold_generator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails/generators/rails/scaffold/scaffold_generator"
+
+module Rails
+  module Generators
+    class ScaffoldGenerator
+      hook_for :policy, in: :pundit, type: :boolean, default: true
+    end
+  end
+end

--- a/lib/generators/rails/scaffold_controller/templates/api_controller.rb.tt
+++ b/lib/generators/rails/scaffold_controller/templates/api_controller.rb.tt
@@ -1,0 +1,61 @@
+<% module_namespacing do -%>
+class <%= controller_class_name %>Controller < ApplicationController
+  before_action :set_<%= singular_table_name %>, only: %i[ show update destroy ]
+
+  # GET <%= route_url %>
+  def index
+    @<%= plural_table_name %> = policy_scope(<%= orm_class.all(class_name) %>)
+    render json: @<%= plural_table_name %>
+  end
+
+  # GET <%= route_url %>/1
+  def show
+    authorize @<%= singular_table_name %>
+    render json: @<%= singular_table_name %>
+  end
+
+  # POST <%= route_url %>
+  def create
+    @<%= singular_table_name %> = <%= orm_class.build(class_name, "#{singular_table_name}_params") %>
+    authorize @<%= singular_table_name %>
+
+    if @<%= orm_instance.save %>
+      render json: @<%= singular_table_name %>, status: :created, location: @<%= singular_table_name %>
+    else
+      render json: @<%= orm_instance.errors %>, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT <%= route_url %>/1
+  def update
+    authorize @<%= singular_table_name %>
+    if @<%= orm_instance.update("#{singular_table_name}_params") %>
+      render json: @<%= singular_table_name %>
+    else
+      render json: @<%= orm_instance.errors %>, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE <%= route_url %>/1
+  def destroy
+    authorize @<%= singular_table_name %>
+    @<%= orm_instance.destroy %>
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_<%= singular_table_name %>
+      @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
+      authorize @<%= singular_table_name %>, only: [:show, :update, :destroy]
+    end
+
+    # Only allow a list of trusted parameters through.
+    def <%= "#{singular_table_name}_params" %>
+      <%- if attributes_names.empty? -%>
+      params.fetch(:<%= singular_table_name %>, {})
+      <%- else -%>
+      params.require(:<%= singular_table_name %>).permit(<%= permitted_params %>)
+      <%- end -%>
+    end
+end
+<% end -%>

--- a/lib/generators/rails/scaffold_controller/templates/controller.rb.tt
+++ b/lib/generators/rails/scaffold_controller/templates/controller.rb.tt
@@ -1,0 +1,71 @@
+<% module_namespacing do -%>
+class <%= controller_class_name %>Controller < ApplicationController
+  before_action :set_<%= singular_table_name %>, only: %i[show edit update destroy]
+
+  # GET <%= route_url %>
+  def index
+    @<%= plural_table_name %> = policy_scope(<%= orm_class.all(class_name) %>)
+  end
+
+  # GET <%= route_url %>/1
+  def show
+    authorize @<%= singular_table_name %>
+  end
+
+  # GET <%= route_url %>/new
+  def new
+    @<%= singular_table_name %> = <%= orm_class.build(class_name) %>
+    authorize @<%= singular_table_name %>
+  end
+
+  # GET <%= route_url %>/1/edit
+  def edit
+    authorize @<%= singular_table_name %>
+  end
+
+  # POST <%= route_url %>
+  def create
+    @<%= singular_table_name %> = <%= orm_class.build(class_name, "#{singular_table_name}_params") %>
+    authorize @<%= singular_table_name %>
+
+    if @<%= orm_instance.save %>
+      redirect_to <%= redirect_resource_name %>, notice: <%= %("#{human_name} was successfully created.") %>
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT <%= route_url %>/1
+  def update
+    authorize @<%= singular_table_name %>
+    if @<%= orm_instance.update("#{singular_table_name}_params") %>
+      redirect_to <%= redirect_resource_name %>, notice: <%= %("#{human_name} was successfully updated.") %>, status: :see_other
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE <%= route_url %>/1
+  def destroy
+    authorize @<%= singular_table_name %>
+    @<%= orm_instance.destroy %>
+    redirect_to <%= index_helper %>_url, notice: <%= %("#{human_name} was successfully destroyed.") %>, status: :see_other
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_<%= singular_table_name %>
+      @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
+      authorize @<%= singular_table_name %>
+    end
+
+    # Only allow a list of trusted parameters through.
+    def <%= "#{singular_table_name}_params" %>
+      <%- if attributes_names.empty? -%>
+      params.fetch(:<%= singular_table_name %>, {})
+      <%- else -%>
+      params.require(:<%= singular_table_name %>).permit(<%= permitted_params %>)
+      <%- end -%>
+    end
+end
+<% end -%>

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -8,6 +8,7 @@ require "active_support/core_ext/object/blank"
 require "active_support/core_ext/module/introspection"
 require "active_support/dependencies/autoload"
 require "pundit/authorization"
+require "pundit/railtie" if defined?(Rails)
 
 # @api private
 # To avoid name clashes with common Error naming when mixing in Pundit,

--- a/lib/pundit/railtie.rb
+++ b/lib/pundit/railtie.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails/railtie"
+
+module Pundit
+  class Railtie < Rails::Railtie
+    generators do |app|
+      Rails::Generators.configure! app.config.generators
+      templates_dir = File.expand_path("../generators/rails/scaffold_controller/templates", __dir__)
+      Rails::Generators::ScaffoldControllerGenerator.source_paths.unshift(templates_dir)
+      require "generators/pundit/scaffold/scaffold_generator"
+    end
+  end
+end

--- a/pundit.gemspec
+++ b/pundit.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "actionpack", ">= 3.0.0"
   gem.add_development_dependency "activemodel", ">= 3.0.0"
   gem.add_development_dependency "bundler"
+  gem.add_development_dependency "generator_spec"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "railties", ">= 3.0.0"
   gem.add_development_dependency "rake"

--- a/spec/generators/scaffold_controller_generator_spec.rb
+++ b/spec/generators/scaffold_controller_generator_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "generator_spec"
+require "rails/generators/rails/scaffold_controller/scaffold_controller_generator"
+
+describe Rails::Generators::ScaffoldControllerGenerator, type: :generator do
+  destination File.expand_path("../../tmp", __dir__)
+  let(:args) { %w[Post --no-helper --skip-template-engine --skip-routes --skip-helpers] }
+
+  before do
+    prepare_destination
+    # NOTE: Set up the templates directory, similar to Pundit::Railtie
+    templates_dir = File.expand_path("../../lib/generators/rails/scaffold_controller/templates", __dir__)
+    Rails::Generators::ScaffoldControllerGenerator.source_paths.unshift(templates_dir)
+
+    run_generator(args)
+  end
+
+  it "generates a scaffold controller with Pundit integration" do
+    assert_file "app/controllers/posts_controller.rb" do |content|
+      expect(content).to include("class PostsController < ApplicationController")
+
+      %w[index show new edit create update destroy].each do |action|
+        expect(content).to include("def #{action}")
+      end
+
+      expect(content).to include("authorize @post")
+      expect(content).to include("policy_scope(Post.all)")
+    end
+  end
+
+  context "when API mode" do
+    let(:args) { %w[Post --api --no-helper --skip-template-engine --skip-routes --skip-helpers] }
+
+    it "generates a scaffold API controller with Pundit integration" do
+      assert_file "app/controllers/posts_controller.rb" do |content|
+        expect(content).to include("class PostsController < ApplicationController")
+        expect(content).to include("render json: @posts")
+
+        %w[index show create update destroy].each do |action|
+          expect(content).to include("def #{action}")
+        end
+
+        expect(content).to include("authorize @post")
+        expect(content).to include("policy_scope(Post.all)")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ require "active_support"
 require "active_support/core_ext"
 require "active_model/naming"
 require "action_controller/metal/strong_parameters"
+require "generator_spec"
 
 class PostPolicy < Struct.new(:user, :post)
   class Scope < Struct.new(:user, :scope)


### PR DESCRIPTION
This PR introduces a Pundit generator for Rails scaffolds and adds `authorize` and `policy_scope` Pundit's methods to scaffolded controllers. It modifies the scaffold generator to include a hook for Pundit policies and overrides scaffold controller templates through a Railtie to add Pundit's methods.
Example scaffold command:
```
# rails g scaffold Post
      invoke  active_record
      create    db/migrate/20240225223237_create_posts.rb
      create    app/models/post.rb
      invoke    rspec
      create      spec/models/post_spec.rb
      invoke  resource_route
       route    resources :posts
      invoke  scaffold_controller
      create    app/controllers/posts_controller.rb
      invoke    erb
      create      app/views/posts
      create      app/views/posts/index.html.erb
      create      app/views/posts/edit.html.erb
      create      app/views/posts/show.html.erb
      create      app/views/posts/new.html.erb
      create      app/views/posts/_form.html.erb
      create      app/views/posts/_post.html.erb
      invoke    resource_route
      invoke    rspec
      create      spec/requests/posts_spec.rb
      create      spec/views/posts/edit.html.erb_spec.rb
      create      spec/views/posts/index.html.erb_spec.rb
      create      spec/views/posts/new.html.erb_spec.rb
      create      spec/views/posts/show.html.erb_spec.rb
      create      spec/routing/posts_routing_spec.rb
      invoke    helper
      create      app/helpers/posts_helper.rb
      invoke      rspec
      create        spec/helpers/posts_helper_spec.rb
      invoke    jbuilder
      create      app/views/posts/index.json.jbuilder
      create      app/views/posts/show.json.jbuilder
      create      app/views/posts/_post.json.jbuilder
      invoke  policy
      create    app/policies/post_policy.rb
      invoke    rspec
      create      spec/policies/post_policy_spec.rb
```
Generated `PostsController`:
```
class PostsController < ApplicationController
  before_action :set_post, only: %i[show edit update destroy]

  # GET /posts
  def index
    @posts = policy_scope(Post.all)
  end

  # GET /posts/1
  def show
    authorize @post
  end

  # GET /posts/new
  def new
    @post = Post.new
    authorize @post
  end

  # GET /posts/1/edit
  def edit
    authorize @post
  end

  # POST /posts
  def create
    @post = Post.new(post_params)
    authorize @post

    if @post.save
      redirect_to @post, notice: "Post was successfully created."
    else
      render :new, status: :unprocessable_entity
    end
  end

  # PATCH/PUT /posts/1
  def update
    authorize @post
    if @post.update(post_params)
      redirect_to @post, notice: "Post was successfully updated.", status: :see_other
    else
      render :edit, status: :unprocessable_entity
    end
  end

  # DELETE /posts/1
  def destroy
    authorize @post
    @post.destroy!
    redirect_to posts_url, notice: "Post was successfully destroyed.", status: :see_other
  end

  private
    # Use callbacks to share common setup or constraints between actions.
    def set_post
      @post = Post.find(params[:id])
      authorize @post
    end

    # Only allow a list of trusted parameters through.
    def post_params
      params.fetch(:post, {})
    end
end
```