### PR TITLE
First pass of Pundit::Context

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -9,6 +9,8 @@ require "active_support/core_ext/module/introspection"
 require "active_support/dependencies/autoload"
 require "pundit/authorization"
 require "pundit/context"
+require "pundit/cache_store/null_store"
+require "pundit/cache_store/hash_store"
 
 # @api private
 # To avoid name clashes with common Error naming when mixing in Pundit,
@@ -66,8 +68,14 @@ module Pundit
 
   class << self
     # @see [Pundit::Context#authorize]
-    def authorize(user, record, query, policy_class: nil, cache: {})
-      Context.new(user: user, policy_cache: cache).authorize(record, query: query, policy_class: policy_class)
+    def authorize(user, record, query, policy_class: nil, cache: nil)
+      context = if cache
+        Context.new(user: user, policy_cache: cache)
+      else
+        Context.new(user: user)
+      end
+
+      context.authorize(record, query: query, policy_class: policy_class)
     end
 
     # @see [Pundit::Context#policy_scope]

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -8,6 +8,7 @@ require "active_support/core_ext/object/blank"
 require "active_support/core_ext/module/introspection"
 require "active_support/dependencies/autoload"
 require "pundit/authorization"
+require "pundit/context"
 
 # @api private
 # To avoid name clashes with common Error naming when mixing in Pundit,
@@ -64,104 +65,29 @@ module Pundit
   end
 
   class << self
-    # Retrieves the policy for the given record, initializing it with the
-    # record and user and finally throwing an error if the user is not
-    # authorized to perform the given action.
-    #
-    # @param user [Object] the user that initiated the action
-    # @param possibly_namespaced_record [Object, Array] the object we're checking permissions of
-    # @param query [Symbol, String] the predicate method to check on the policy (e.g. `:show?`)
-    # @param policy_class [Class] the policy class we want to force use of
-    # @param cache [#[], #[]=] a Hash-like object to cache the found policy instance in
-    # @raise [NotAuthorizedError] if the given query method returned false
-    # @return [Object] Always returns the passed object record
-    def authorize(user, possibly_namespaced_record, query, policy_class: nil, cache: {})
-      record = pundit_model(possibly_namespaced_record)
-      policy = if policy_class
-        policy_class.new(user, record)
-      else
-        cache[possibly_namespaced_record] ||= policy!(user, possibly_namespaced_record)
-      end
-
-      raise NotAuthorizedError, query: query, record: record, policy: policy unless policy.public_send(query)
-
-      record
+    # @see [Pundit::Context#authorize]
+    def authorize(user, record, query, policy_class: nil, cache: {})
+      Context.new(user: user, policy_cache: cache).authorize(record, query: query, policy_class: policy_class)
     end
 
-    # Retrieves the policy scope for the given record.
-    #
-    # @see https://github.com/varvet/pundit#scopes
-    # @param user [Object] the user that initiated the action
-    # @param scope [Object] the object we're retrieving the policy scope for
-    # @raise [InvalidConstructorError] if the policy constructor called incorrectly
-    # @return [Scope{#resolve}, nil] instance of scope class which can resolve to a scope
-    def policy_scope(user, scope)
-      policy_scope_class = PolicyFinder.new(scope).scope
-      return unless policy_scope_class
-
-      begin
-        policy_scope = policy_scope_class.new(user, pundit_model(scope))
-      rescue ArgumentError
-        raise InvalidConstructorError, "Invalid #<#{policy_scope_class}> constructor is called"
-      end
-
-      policy_scope.resolve
+    # @see [Pundit::Context#policy_scope]
+    def policy_scope(user, *args, **kwargs, &block)
+      Context.new(user: user).policy_scope(*args, **kwargs, &block)
     end
 
-    # Retrieves the policy scope for the given record.
-    #
-    # @see https://github.com/varvet/pundit#scopes
-    # @param user [Object] the user that initiated the action
-    # @param scope [Object] the object we're retrieving the policy scope for
-    # @raise [NotDefinedError] if the policy scope cannot be found
-    # @raise [InvalidConstructorError] if the policy constructor called incorrectly
-    # @return [Scope{#resolve}] instance of scope class which can resolve to a scope
-    def policy_scope!(user, scope)
-      policy_scope_class = PolicyFinder.new(scope).scope!
-      return unless policy_scope_class
-
-      begin
-        policy_scope = policy_scope_class.new(user, pundit_model(scope))
-      rescue ArgumentError
-        raise InvalidConstructorError, "Invalid #<#{policy_scope_class}> constructor is called"
-      end
-
-      policy_scope.resolve
+    # @see [Pundit::Context#policy_scope!]
+    def policy_scope!(user, *args, **kwargs, &block)
+      Context.new(user: user).policy_scope!(*args, **kwargs, &block)
     end
 
-    # Retrieves the policy for the given record.
-    #
-    # @see https://github.com/varvet/pundit#policies
-    # @param user [Object] the user that initiated the action
-    # @param record [Object] the object we're retrieving the policy for
-    # @raise [InvalidConstructorError] if the policy constructor called incorrectly
-    # @return [Object, nil] instance of policy class with query methods
-    def policy(user, record)
-      policy = PolicyFinder.new(record).policy
-      policy&.new(user, pundit_model(record))
-    rescue ArgumentError
-      raise InvalidConstructorError, "Invalid #<#{policy}> constructor is called"
+    # @see [Pundit::Context#policy]
+    def policy(user, *args, **kwargs, &block)
+      Context.new(user: user).policy(*args, **kwargs, &block)
     end
 
-    # Retrieves the policy for the given record.
-    #
-    # @see https://github.com/varvet/pundit#policies
-    # @param user [Object] the user that initiated the action
-    # @param record [Object] the object we're retrieving the policy for
-    # @raise [NotDefinedError] if the policy cannot be found
-    # @raise [InvalidConstructorError] if the policy constructor called incorrectly
-    # @return [Object] instance of policy class with query methods
-    def policy!(user, record)
-      policy = PolicyFinder.new(record).policy!
-      policy.new(user, pundit_model(record))
-    rescue ArgumentError
-      raise InvalidConstructorError, "Invalid #<#{policy}> constructor is called"
-    end
-
-    private
-
-    def pundit_model(record)
-      record.is_a?(Array) ? record.last : record
+    # @see [Pundit::Context#policy!]
+    def policy!(user, *args, **kwargs, &block)
+      Context.new(user: user).policy!(*args, **kwargs, &block)
     end
   end
 

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -10,7 +10,7 @@ require "active_support/dependencies/autoload"
 require "pundit/authorization"
 require "pundit/context"
 require "pundit/cache_store/null_store"
-require "pundit/cache_store/hash_store"
+require "pundit/cache_store/legacy_store"
 
 # @api private
 # To avoid name clashes with common Error naming when mixing in Pundit,

--- a/lib/pundit/authorization.rb
+++ b/lib/pundit/authorization.rb
@@ -19,7 +19,7 @@ module Pundit
     def pundit
       @pundit ||= Pundit::Context.new(
         user: pundit_user,
-        policy_cache: policies
+        policy_cache: Pundit::CacheStore::HashStore.new(policies)
       )
     end
 

--- a/lib/pundit/authorization.rb
+++ b/lib/pundit/authorization.rb
@@ -19,7 +19,7 @@ module Pundit
     def pundit
       @pundit ||= Pundit::Context.new(
         user: pundit_user,
-        policy_cache: Pundit::CacheStore::HashStore.new(policies)
+        policy_cache: Pundit::CacheStore::LegacyStore.new(policies)
       )
     end
 

--- a/lib/pundit/authorization.rb
+++ b/lib/pundit/authorization.rb
@@ -106,9 +106,9 @@ module Pundit
     #
     # @see https://github.com/varvet/pundit#policies
     # @param record [Object] the object we're retrieving the policy for
-    # @return [Object, nil] instance of policy class with query methods
+    # @return [Object] instance of policy class with query methods
     def policy(record)
-      policies[record] ||= pundit.policy!(record)
+      pundit.policy!(record)
     end
 
     # Retrieves a set of permitted attributes from the policy by instantiating

--- a/lib/pundit/authorization.rb
+++ b/lib/pundit/authorization.rb
@@ -15,6 +15,14 @@ module Pundit
 
     protected
 
+    # @return [Pundit::Context] a new instance of {Pundit::Context} with the current user
+    def pundit
+      @pundit ||= Pundit::Context.new(
+        user: pundit_user,
+        policy_cache: policies
+      )
+    end
+
     # @return [Boolean] whether authorization has been performed, i.e. whether
     #                   one {#authorize} or {#skip_authorization} has been called
     def pundit_policy_authorized?
@@ -64,7 +72,7 @@ module Pundit
 
       @_pundit_policy_authorized = true
 
-      Pundit.authorize(pundit_user, record, query, policy_class: policy_class, cache: policies)
+      pundit.authorize(record, query: query, policy_class: policy_class)
     end
 
     # Allow this action not to perform authorization.
@@ -100,7 +108,7 @@ module Pundit
     # @param record [Object] the object we're retrieving the policy for
     # @return [Object, nil] instance of policy class with query methods
     def policy(record)
-      policies[record] ||= Pundit.policy!(pundit_user, record)
+      policies[record] ||= pundit.policy!(record)
     end
 
     # Retrieves a set of permitted attributes from the policy by instantiating
@@ -162,7 +170,7 @@ module Pundit
     private
 
     def pundit_policy_scope(scope)
-      policy_scopes[scope] ||= Pundit.policy_scope!(pundit_user, scope)
+      policy_scopes[scope] ||= pundit.policy_scope!(scope)
     end
   end
 end

--- a/lib/pundit/cache_store/hash_store.rb
+++ b/lib/pundit/cache_store/hash_store.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Pundit
+  module CacheStore
+    # @api private
+    class HashStore
+      def initialize(hash = {})
+        @store = hash
+      end
+
+      def fetch(key)
+        @store[key] ||= yield
+      end
+    end
+  end
+end

--- a/lib/pundit/cache_store/legacy_store.rb
+++ b/lib/pundit/cache_store/legacy_store.rb
@@ -3,13 +3,14 @@
 module Pundit
   module CacheStore
     # @api private
-    class HashStore
+    class LegacyStore
       def initialize(hash = {})
         @store = hash
       end
 
-      def fetch(key)
-        @store[key] ||= yield
+      def fetch(user:, record:)
+        _ = user
+        @store[record] ||= yield
       end
     end
   end

--- a/lib/pundit/cache_store/null_store.rb
+++ b/lib/pundit/cache_store/null_store.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Pundit
+  module CacheStore
+    # @api private
+    class NullStore
+      @instance = new
+
+      class << self
+        attr_reader :instance
+      end
+
+      def fetch(*, **)
+        yield
+      end
+    end
+  end
+end

--- a/lib/pundit/context.rb
+++ b/lib/pundit/context.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module Pundit
+  class Context
+    def initialize(user:, policy_cache: {})
+      @user = user
+      @policy_cache = policy_cache
+    end
+
+    attr_reader :user
+
+    # @api private
+    attr_reader :policy_cache
+
+    # Retrieves the policy for the given record, initializing it with the
+    # record and user and finally throwing an error if the user is not
+    # authorized to perform the given action.
+    #
+    # @param user [Object] the user that initiated the action
+    # @param possibly_namespaced_record [Object, Array] the object we're checking permissions of
+    # @param query [Symbol, String] the predicate method to check on the policy (e.g. `:show?`)
+    # @param policy_class [Class] the policy class we want to force use of
+    # @raise [NotAuthorizedError] if the given query method returned false
+    # @return [Object] Always returns the passed object record
+    def authorize(possibly_namespaced_record, query:, policy_class:)
+      record = pundit_model(possibly_namespaced_record)
+      policy = if policy_class
+        policy_class.new(user, record)
+      else
+        policy_cache[possibly_namespaced_record] ||= policy!(possibly_namespaced_record)
+      end
+
+      raise NotAuthorizedError, query: query, record: record, policy: policy unless policy.public_send(query)
+
+      record
+    end
+
+    # Retrieves the policy scope for the given record.
+    #
+    # @see https://github.com/varvet/pundit#scopes
+    # @param user [Object] the user that initiated the action
+    # @param scope [Object] the object we're retrieving the policy scope for
+    # @raise [InvalidConstructorError] if the policy constructor called incorrectly
+    # @return [Scope{#resolve}, nil] instance of scope class which can resolve to a scope
+    def policy_scope(scope)
+      policy_scope_class = policy_finder(scope).scope
+      return unless policy_scope_class
+
+      begin
+        policy_scope = policy_scope_class.new(user, pundit_model(scope))
+      rescue ArgumentError
+        raise InvalidConstructorError, "Invalid #<#{policy_scope_class}> constructor is called"
+      end
+
+      policy_scope.resolve
+    end
+
+    # Retrieves the policy scope for the given record.
+    #
+    # @see https://github.com/varvet/pundit#scopes
+    # @param user [Object] the user that initiated the action
+    # @param scope [Object] the object we're retrieving the policy scope for
+    # @raise [NotDefinedError] if the policy scope cannot be found
+    # @raise [InvalidConstructorError] if the policy constructor called incorrectly
+    # @return [Scope{#resolve}] instance of scope class which can resolve to a scope
+    def policy_scope!(scope)
+      policy_scope_class = policy_finder(scope).scope!
+      return unless policy_scope_class
+
+      begin
+        policy_scope = policy_scope_class.new(user, pundit_model(scope))
+      rescue ArgumentError
+        raise InvalidConstructorError, "Invalid #<#{policy_scope_class}> constructor is called"
+      end
+
+      policy_scope.resolve
+    end
+
+    # Retrieves the policy for the given record.
+    #
+    # @see https://github.com/varvet/pundit#policies
+    # @param user [Object] the user that initiated the action
+    # @param record [Object] the object we're retrieving the policy for
+    # @raise [InvalidConstructorError] if the policy constructor called incorrectly
+    # @return [Object, nil] instance of policy class with query methods
+    def policy(record)
+      policy = policy_finder(record).policy
+      policy&.new(user, pundit_model(record))
+    rescue ArgumentError
+      raise InvalidConstructorError, "Invalid #<#{policy}> constructor is called"
+    end
+
+    # Retrieves the policy for the given record.
+    #
+    # @see https://github.com/varvet/pundit#policies
+    # @param user [Object] the user that initiated the action
+    # @param record [Object] the object we're retrieving the policy for
+    # @raise [NotDefinedError] if the policy cannot be found
+    # @raise [InvalidConstructorError] if the policy constructor called incorrectly
+    # @return [Object] instance of policy class with query methods
+    def policy!(record)
+      policy = policy_finder(record).policy!
+      policy.new(user, pundit_model(record))
+    rescue ArgumentError
+      raise InvalidConstructorError, "Invalid #<#{policy}> constructor is called"
+    end
+
+    private
+
+    def policy_finder(record)
+      PolicyFinder.new(record)
+    end
+
+    def pundit_model(record)
+      record.is_a?(Array) ? record.last : record
+    end
+  end
+end

--- a/lib/pundit/context.rb
+++ b/lib/pundit/context.rb
@@ -2,7 +2,7 @@
 
 module Pundit
   class Context
-    def initialize(user:, policy_cache: {})
+    def initialize(user:, policy_cache: CacheStore::NullStore.instance)
       @user = user
       @policy_cache = policy_cache
     end
@@ -27,7 +27,9 @@ module Pundit
       policy = if policy_class
         policy_class.new(user, record)
       else
-        policy_cache[possibly_namespaced_record] ||= policy!(possibly_namespaced_record)
+        policy_cache.fetch(possibly_namespaced_record) do
+          policy!(possibly_namespaced_record)
+        end
       end
 
       raise NotAuthorizedError, query: query, record: record, policy: policy unless policy.public_send(query)

--- a/lib/pundit/context.rb
+++ b/lib/pundit/context.rb
@@ -55,7 +55,7 @@ module Pundit
       policy_scope.resolve
     end
 
-    # Retrieves the policy scope for the given record.
+    # Retrieves the policy scope for the given record. Raises if not found.
     #
     # @see https://github.com/varvet/pundit#scopes
     # @param user [Object] the user that initiated the action
@@ -90,7 +90,7 @@ module Pundit
       raise InvalidConstructorError, "Invalid #<#{policy}> constructor is called"
     end
 
-    # Retrieves the policy for the given record.
+    # Retrieves the policy for the given record. Raises if not found.
     #
     # @see https://github.com/varvet/pundit#policies
     # @param user [Object] the user that initiated the action

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -64,7 +64,11 @@ RSpec.describe Pundit do
       end.to raise_error(Pundit::NotAuthorizedError, "not allowed to destroy? this Post") do |error|
         expect(error.query).to eq :destroy?
         expect(error.record).to eq post
-        expect(error.policy).to eq Pundit.policy(user, post)
+        expect(error.policy).to have_attributes(
+          user: user,
+          record: post
+        )
+        expect(error.policy).to be_a(PostPolicy)
       end
       # rubocop:enable Style/MultilineBlockChain
     end
@@ -76,7 +80,11 @@ RSpec.describe Pundit do
       end.to raise_error(Pundit::NotAuthorizedError, "not allowed to destroy? this Comment") do |error|
         expect(error.query).to eq :destroy?
         expect(error.record).to eq comment
-        expect(error.policy).to eq Pundit.policy(user, [:project, :admin, comment])
+        expect(error.policy).to have_attributes(
+          user: user,
+          record: comment
+        )
+        expect(error.policy).to be_a(Project::Admin::CommentPolicy)
       end
       # rubocop:enable Style/MultilineBlockChain
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,8 +18,31 @@ require "active_support/core_ext"
 require "active_model/naming"
 require "action_controller/metal/strong_parameters"
 
+module InstanceTracking
+  module ClassMethods
+    def instances
+      @instances || 0
+    end
+
+    attr_writer :instances
+  end
+
+  def self.prepended(other)
+    other.extend(ClassMethods)
+  end
+
+  def initialize(*args, **kwargs, &block)
+    self.class.instances += 1
+    super(*args, **kwargs, &block)
+  end
+end
+
 class BasePolicy
+  prepend InstanceTracking
+
   class BaseScope
+    prepend InstanceTracking
+
     def initialize(user, scope)
       @user = user
       @scope = scope

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,12 +18,32 @@ require "active_support/core_ext"
 require "active_model/naming"
 require "action_controller/metal/strong_parameters"
 
-class PostPolicy < Struct.new(:user, :post)
-  class Scope < Struct.new(:user, :scope)
+class BasePolicy
+  class BaseScope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    attr_reader :user, :scope
+  end
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  attr_reader :user, :record
+end
+
+class PostPolicy < BasePolicy
+  class Scope < BaseScope
     def resolve
       scope.published
     end
   end
+
+  alias post record
 
   def update?
     post.user == user
@@ -50,7 +70,13 @@ class PostPolicy < Struct.new(:user, :post)
   end
 end
 
-class Post < Struct.new(:user)
+class Post
+  def initialize(user = nil)
+    @user = user
+  end
+
+  attr_reader :user
+
   def self.published
     :published
   end
@@ -69,7 +95,7 @@ class Post < Struct.new(:user)
 end
 
 module Customer
-  class Post < Post
+  class Post < ::Post
     def model_name
       OpenStruct.new(param_key: "customer_post")
     end
@@ -92,16 +118,18 @@ class CommentScope
   end
 end
 
-class CommentPolicy < Struct.new(:user, :comment)
-  class Scope < Struct.new(:user, :scope)
+class CommentPolicy < BasePolicy
+  class Scope < BaseScope
     def resolve
       CommentScope.new(scope)
     end
   end
+
+  alias comment record
 end
 
-class PublicationPolicy < Struct.new(:user, :publication)
-  class Scope < Struct.new(:user, :scope)
+class PublicationPolicy < BasePolicy
+  class Scope < BaseScope
     def resolve
       scope.published
     end
@@ -132,7 +160,9 @@ end
 
 class Article; end
 
-class BlogPolicy < Struct.new(:user, :blog); end
+class BlogPolicy < BasePolicy
+  alias blog record
+end
 
 class Blog; end
 
@@ -142,7 +172,7 @@ class ArtificialBlog < Blog
   end
 end
 
-class ArticleTagOtherNamePolicy < Struct.new(:user, :tag)
+class ArticleTagOtherNamePolicy < BasePolicy
   def show?
     true
   end
@@ -150,6 +180,8 @@ class ArticleTagOtherNamePolicy < Struct.new(:user, :tag)
   def destroy?
     false
   end
+
+  alias tag record
 end
 
 class ArticleTag
@@ -158,33 +190,41 @@ class ArticleTag
   end
 end
 
-class CriteriaPolicy < Struct.new(:user, :criteria); end
+class CriteriaPolicy < BasePolicy
+  alias criteria record
+end
 
 module Project
-  class CommentPolicy < Struct.new(:user, :comment)
-    def update?
-      true
-    end
-
-    class Scope < Struct.new(:user, :scope)
+  class CommentPolicy < BasePolicy
+    class Scope < BaseScope
       def resolve
         scope
       end
     end
+
+    def update?
+      true
+    end
+
+    alias comment record
   end
 
-  class CriteriaPolicy < Struct.new(:user, :criteria); end
+  class CriteriaPolicy < BasePolicy
+    alias criteria record
+  end
 
-  class PostPolicy < Struct.new(:user, :post)
-    class Scope < Struct.new(:user, :scope)
+  class PostPolicy < BasePolicy
+    class Scope < BaseScope
       def resolve
         scope.read
       end
     end
+
+    alias post record
   end
 
   module Admin
-    class CommentPolicy < Struct.new(:user, :comment)
+    class CommentPolicy < BasePolicy
       def update?
         true
       end
@@ -196,7 +236,7 @@ module Project
   end
 end
 
-class DenierPolicy < Struct.new(:user, :record)
+class DenierPolicy < BasePolicy
   def update?
     false
   end
@@ -218,7 +258,7 @@ class Controller
   end
 end
 
-class NilClassPolicy < Struct.new(:user, :record)
+class NilClassPolicy < BasePolicy
   class Scope
     def initialize(*)
       raise Pundit::NotDefinedError, "Cannot scope NilClass"
@@ -247,8 +287,8 @@ class Thread
   def self.all; end
 end
 
-class ThreadPolicy < Struct.new(:user, :thread)
-  class Scope < Struct.new(:user, :scope)
+class ThreadPolicy < BasePolicy
+  class Scope < BaseScope
     def resolve
       # deliberate wrong useage of the method
       scope.all(:unvalid, :parameters)
@@ -256,22 +296,34 @@ class ThreadPolicy < Struct.new(:user, :thread)
   end
 end
 
-class PostFourFiveSix < Struct.new(:user); end
+class PostFourFiveSix
+  def initialize(user)
+    @user = user
+  end
+
+  attr_reader(:user)
+end
 
 class CommentFourFiveSix; extend ActiveModel::Naming; end
 
 module ProjectOneTwoThree
-  class CommentFourFiveSixPolicy < Struct.new(:user, :post); end
+  class CommentFourFiveSixPolicy < BasePolicy; end
 
-  class CriteriaFourFiveSixPolicy < Struct.new(:user, :criteria); end
+  class CriteriaFourFiveSixPolicy < BasePolicy; end
 
-  class PostFourFiveSixPolicy < Struct.new(:user, :post); end
+  class PostFourFiveSixPolicy < BasePolicy; end
 
-  class TagFourFiveSix < Struct.new(:user); end
+  class TagFourFiveSix
+    def initialize(user)
+      @user = user
+    end
 
-  class TagFourFiveSixPolicy < Struct.new(:user, :tag); end
+    attr_reader(:user)
+  end
+
+  class TagFourFiveSixPolicy < BasePolicy; end
 
   class AvatarFourFiveSix; extend ActiveModel::Naming; end
 
-  class AvatarFourFiveSixPolicy < Struct.new(:user, :avatar); end
+  class AvatarFourFiveSixPolicy < BasePolicy; end
 end


### PR DESCRIPTION
See https://github.com/varvet/pundit/discussions/774 initial draft/rationale.

## Caution
* We're introducing a new method [`Pundit::Authorization#pundit`](https://github.com/varvet/pundit/blob/d7251544dc552b7fe9f95933882279ae37e566ab/lib/pundit/authorization.rb#L19-L24). This is a namespace that is technically not ours, as this module included in controllers.

## Hopefully this allows us to:
* ... improve/fix existing functionality while staying backwards-compatible, by using [dependency injection](https://github.com/varvet/pundit/blob/d7251544dc552b7fe9f95933882279ae37e566ab/lib/pundit/authorization.rb#L22).
* ... introduce new functionality without necessarily bloating controllers in `Pundit::Authorization`.
* ... introduce an actual API for namespaces rather than overriding `authorize`/`policy`.