### PR TITLE
Considering integrating the Pundit::Context even more

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -71,16 +71,24 @@ module Pundit
     end
 
     # @see [Pundit::Context#policy_scope]
-    def policy_scope(user, ...) = Context.new(user: user).policy_scope(...)
+    def policy_scope(user, *args, **kwargs, &block)
+      Context.new(user: user).policy_scope(*args, **kwargs, &block)
+    end
 
     # @see [Pundit::Context#policy_scope!]
-    def policy_scope!(user, ...) = Context.new(user: user).policy_scope!(...)
+    def policy_scope!(user, *args, **kwargs, &block)
+      Context.new(user: user).policy_scope!(*args, **kwargs, &block)
+    end
 
     # @see [Pundit::Context#policy]
-    def policy(user, ...) = Context.new(user: user).policy(...)
+    def policy(user, *args, **kwargs, &block)
+      Context.new(user: user).policy(*args, **kwargs, &block)
+    end
 
     # @see [Pundit::Context#policy!]
-    def policy!(user, ...) = Context.new(user: user).policy!(...)
+    def policy!(user, *args, **kwargs, &block)
+      Context.new(user: user).policy!(*args, **kwargs, &block)
+    end
   end
 
   # @api private

--- a/lib/pundit/authorization.rb
+++ b/lib/pundit/authorization.rb
@@ -15,7 +15,7 @@ module Pundit
 
     protected
 
-    # @return [Pundit::Core] a new instance of {Pundit::Core} with the current user
+    # @return [Pundit::Context] a new instance of {Pundit::Context} with the current user
     def pundit
       @pundit ||= Pundit::Context.new(
         user: pundit_user,

--- a/lib/pundit/context.rb
+++ b/lib/pundit/context.rb
@@ -34,7 +34,7 @@ module Pundit
     def authorize(possibly_namespaced_record, query:, policy_class:)
       record = pundit_model(possibly_namespaced_record)
       policy = if policy_class
-        policy_class.new(user, record)
+        policy_cache[possibly_namespaced_record] ||= policy_class.new(user, record)
       else
         policy_cache[possibly_namespaced_record] ||= policy!(possibly_namespaced_record)
       end
@@ -93,7 +93,7 @@ module Pundit
     # @raise [InvalidConstructorError] if the policy constructor called incorrectly
     # @return [Object, nil] instance of policy class with query methods
     def policy(record)
-      policy = policy_finder(record).policy
+      policy = policy_cache[record] || policy_finder(record).policy
       policy&.new(user, pundit_model(record))
     rescue ArgumentError
       raise InvalidConstructorError, "Invalid #<#{policy}> constructor is called"
@@ -108,7 +108,7 @@ module Pundit
     # @raise [InvalidConstructorError] if the policy constructor called incorrectly
     # @return [Object] instance of policy class with query methods
     def policy!(record)
-      policy = policy_finder(record).policy!
+      policy = policy_cache[record] || policy_finder(record).policy!
       policy.new(user, pundit_model(record))
     rescue ArgumentError
       raise InvalidConstructorError, "Invalid #<#{policy}> constructor is called"

--- a/lib/pundit/context.rb
+++ b/lib/pundit/context.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+module Pundit
+  class Context
+    def initialize(user:, policy_cache: {}, scope_cache: {})
+      @user = user
+
+      @policy_cache = policy_cache
+      @scope_cache = scope_cache
+    end
+
+    attr_reader :user
+
+    def with_user(new_user)
+      clone.tap { _1.instance_variable_set(:@user, new_user) }
+    end
+
+    # @api private
+    attr_reader :policy_cache
+
+    # @api private
+    attr_reader :scope_cache
+
+    # Retrieves the policy for the given record, initializing it with the
+    # record and user and finally throwing an error if the user is not
+    # authorized to perform the given action.
+    #
+    # @param user [Object] the user that initiated the action
+    # @param possibly_namespaced_record [Object, Array] the object we're checking permissions of
+    # @param query [Symbol, String] the predicate method to check on the policy (e.g. `:show?`)
+    # @param policy_class [Class] the policy class we want to force use of
+    # @raise [NotAuthorizedError] if the given query method returned false
+    # @return [Object] Always returns the passed object record
+    def authorize(possibly_namespaced_record, query:, policy_class:)
+      record = pundit_model(possibly_namespaced_record)
+      policy = if policy_class
+        policy_class.new(user, record)
+      else
+        policy_cache[possibly_namespaced_record] ||= policy!(possibly_namespaced_record)
+      end
+
+      raise NotAuthorizedError, query: query, record: record, policy: policy unless policy.public_send(query)
+
+      record
+    end
+
+    # Retrieves the policy scope for the given record.
+    #
+    # @see https://github.com/varvet/pundit#scopes
+    # @param user [Object] the user that initiated the action
+    # @param scope [Object] the object we're retrieving the policy scope for
+    # @raise [InvalidConstructorError] if the policy constructor called incorrectly
+    # @return [Scope{#resolve}, nil] instance of scope class which can resolve to a scope
+    def policy_scope(scope)
+      policy_scope_class = policy_finder(scope).scope
+      return unless policy_scope_class
+
+      begin
+        policy_scope = policy_scope_class.new(user, pundit_model(scope))
+      rescue ArgumentError
+        raise InvalidConstructorError, "Invalid #<#{policy_scope_class}> constructor is called"
+      end
+
+      policy_scope.resolve
+    end
+
+    # Retrieves the policy scope for the given record.
+    #
+    # @see https://github.com/varvet/pundit#scopes
+    # @param user [Object] the user that initiated the action
+    # @param scope [Object] the object we're retrieving the policy scope for
+    # @raise [NotDefinedError] if the policy scope cannot be found
+    # @raise [InvalidConstructorError] if the policy constructor called incorrectly
+    # @return [Scope{#resolve}] instance of scope class which can resolve to a scope
+    def policy_scope!(scope)
+      policy_scope_class = policy_finder(scope).scope!
+      return unless policy_scope_class
+
+      begin
+        policy_scope = policy_scope_class.new(user, pundit_model(scope))
+      rescue ArgumentError
+        raise InvalidConstructorError, "Invalid #<#{policy_scope_class}> constructor is called"
+      end
+
+      policy_scope.resolve
+    end
+
+    # Retrieves the policy for the given record.
+    #
+    # @see https://github.com/varvet/pundit#policies
+    # @param user [Object] the user that initiated the action
+    # @param record [Object] the object we're retrieving the policy for
+    # @raise [InvalidConstructorError] if the policy constructor called incorrectly
+    # @return [Object, nil] instance of policy class with query methods
+    def policy(record)
+      policy = policy_finder(record).policy
+      policy&.new(user, pundit_model(record))
+    rescue ArgumentError
+      raise InvalidConstructorError, "Invalid #<#{policy}> constructor is called"
+    end
+
+    # Retrieves the policy for the given record.
+    #
+    # @see https://github.com/varvet/pundit#policies
+    # @param user [Object] the user that initiated the action
+    # @param record [Object] the object we're retrieving the policy for
+    # @raise [NotDefinedError] if the policy cannot be found
+    # @raise [InvalidConstructorError] if the policy constructor called incorrectly
+    # @return [Object] instance of policy class with query methods
+    def policy!(record)
+      policy = policy_finder(record).policy!
+      policy.new(user, pundit_model(record))
+    rescue ArgumentError
+      raise InvalidConstructorError, "Invalid #<#{policy}> constructor is called"
+    end
+
+    private
+
+    def policy_finder(...)
+      PolicyFinder.new(...)
+    end
+
+    def pundit_model(record)
+      record.is_a?(Array) ? record.last : record
+    end
+  end
+end

--- a/lib/pundit/context.rb
+++ b/lib/pundit/context.rb
@@ -116,8 +116,8 @@ module Pundit
 
     private
 
-    def policy_finder(...)
-      PolicyFinder.new(...)
+    def policy_finder(*args, **kwargs, &block)
+      PolicyFinder.new(*args, **kwargs, &block)
     end
 
     def pundit_model(record)

--- a/spec/authorization_spec.rb
+++ b/spec/authorization_spec.rb
@@ -12,6 +12,15 @@ describe Pundit::Authorization do
   let(:article_tag) { ArticleTag.new }
   let(:wiki) { Wiki.new }
 
+  describe "keeping context" do
+    context "policy_class" do
+      it "is kept between authorize and policy calls" do
+        expect(controller.authorize(post, :create?, policy_class: PublicationPolicy)).to be_truthy
+        expect(controller.policy(post).class).to be PublicationPolicy
+      end
+    end
+  end
+
   describe "#verify_authorized" do
     it "does nothing when authorized" do
       controller.authorize(post)


### PR DESCRIPTION
Prefer `policy_cache` if available to `policy_finder`. 

I'm unsure if there are other implications for this, but for the use
case of sharing context between the typical controller use (`authorize`)
vs the view typical use (`policy`) this adds value. Without this the
`authorize` and `policy` methods are still disconnected as far as I can
tell.

It looks like you were thoughtful about only choosing the else clause to
be stored in the cache, so I might be missing a consideration you were
making. But, I'd argue that if the client specifies a policy_class for
a given record then the goal is for that policy_class to apply to all
records through the pundit-based interactions. It was our intention at
least.