### PR TITLE
Release v2.3.2

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -1,0 +1,33 @@
+name: Push Gem
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  push:
+    if: github.repository == 'varvet/pundit'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      # Set up
+      - name: Harden Runner
+        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@cacc9f1c0b3f4eb8a16a6bb0ed10897b43b9de49 # v1.176.0
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      # Release
+      - uses: rubygems/release-gem@612653d273a73bdae1df8453e090060bb4db5f31 # v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,18 @@
 
 ## Unreleased
 
-- Dropped support for Ruby 3.0 (#796)
+## 2.3.2 (2024-05-08)
+
+- Refactor: First pass of Pundit::Context (#797)
+
+## Changed
 
 - Update `ApplicationPolicy` generator to qualify the `Scope` class name (#792)
 - Policy generator uses `NoMethodError` to indicate `#resolve` is not implemented (#776)
+
+## Deprecated
+
+- Dropped support for Ruby 3.0 (#796)
 
 ## 2.3.1 (2023-07-17)
 

--- a/lib/pundit/version.rb
+++ b/lib/pundit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pundit
-  VERSION = "2.3.1"
+  VERSION = "2.3.2"
 end


### PR DESCRIPTION
- Add trusted publishing (rubygems)
- Bump to v2.3.2

## To do

- [x] Commit changes:
  - [x] Bump `Pundit::VERSION` in `lib/pundit/version.rb`.
  - [x] Update `CHANGELOG.md`.
- [ ] Run `rake release`.
- [x] Open pull request 🚀
- [ ] Make an announcement in [Pundit discussions](https://github.com/varvet/pundit/discussions/categories/announcements).