### PR TITLE
Workaround JRuby 9.4 and jruby-head are failing (only on CI)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,12 @@ jobs:
       with:
         rubygems: latest
         ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true
+        bundler-cache: ${{ !startsWith(matrix.ruby-version, 'jruby') }}
+    - name: Bundler install (JRuby workaround)
+      if: ${{ startsWith(matrix.ruby-version, 'jruby') }}
+      run: |
+        gem install psych
+        bundle install
     - name: Run tests
       run: bundle exec rspec
 


### PR DESCRIPTION
I'll try to figure out _why_ this is needed, but in the meantime I'd like to be able to merge pull requests.