### PR TITLE
Release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## Unreleased
 
+## 2.4.0 (2024-08-26)
+
+## Changed
+
 - Improve the `NotAuthorizedError` message to include the policy class.
-Furthermore, in the case where the record passed is a class instead of an instance, the class name is given. (#812)
+  Furthermore, in the case where the record passed is a class instead of an instance, the class name is given. (#812)
+
+## Added
+
 - Add customizable permit matcher description (#806)
 - Add support for filter_run_when_matching :focus with permissions helper. (#820)
 

--- a/lib/pundit/version.rb
+++ b/lib/pundit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pundit
-  VERSION = "2.3.2"
+  VERSION = "2.4.0"
 end


### PR DESCRIPTION
## Improve `NotAuthorizedError` message to include policy class (#812)

Default error message changed from:
> not allowed to destroy? this Comment

To include the policy class:
> not allowed to Project::Admin::CommentPolicy#destroy? this Comment

## Improve `NotAuthorizedError` when record is a class

Before:
> not allowed to index? this Class

After:
> not allowed to PostPolicy#index? Post

## Allow customizing rspec matcher description (#806)

Before:
```
PostPolicy
  update? and show?
    is expected to permit #<User:0x0000000104aefd80> and #<Post:0x0000000104aef8d0 @user=#<User:0x0000000104aefd80>>
```

In `spec_helper.rb`:
```ruby
Pundit::RSpec::Matchers.description = ->(user, record) do
  "permit user with role #{user.role} to access record with ID #{record.id}"
end
```

After:
```
PostPolicy
  update? and show?
    is expected to permit user with role admin to access record with ID 130
```

## Add support for filter_run_when_matching :focus with permissions helper (#820)

If your RSpec config has filter_run_when_matching :focus, you may tag the permissions helper like so:

```ruby
permissions :show?, :focus do
```

## To do

- [x] Make changes:
  - [x] Bump `Pundit::VERSION` in `lib/pundit/version.rb`.
  - [x] Update `CHANGELOG.md`.
- [x] Open pull request 🚀 and merge it.
- [ ] Run [push gem](https://github.com/varvet/pundit/actions/workflows/push_gem.yml) GitHub Action.
- [ ] Make an announcement in [Pundit discussions](https://github.com/varvet/pundit/discussions/categories/announcements)