### PR TITLE
add hook for clear pundit context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Added
 
-- Add `Pundit::Authorization#clear_pundit_context!` hook to clear the context (#830)
+- Add `Pundit::Authorization#pundit_reset!` hook to reset the policy and policy scope cache. (#830)
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Added
+
+- Add `Pundit::Authorization#clear_pundit_context!` hook to clear the context (#830)
+
 ## Changed
 
 - Deprecated `Pundit::SUFFIX`, moved it to `Pundit::PolicyFinder::SUFFIX` (#835)

--- a/README.md
+++ b/README.md
@@ -669,7 +669,7 @@ class ApplicationController
 
   def switch_account
     set_current_account(Account.find(params[:account_id]))
-    clear_pundit_context!
+    pundit_reset!
   end
 
   def pundit_user

--- a/README.md
+++ b/README.md
@@ -660,6 +660,24 @@ class ApplicationController
 end
 ```
 
+If you need to change the context for any reason, you will need to clear the caches stored in the context. You can use the hook below to do this.
+
+```ruby
+class ApplicationController
+  include Pundit::Authorization
+  before_action :switch_account, if: :should_switch_account?
+
+  def switch_account
+    set_current_account(Account.find(params[:account_id]))
+    clear_pundit_context!
+  end
+
+  def pundit_user
+    UserContext.new(current_user, current_account)
+  end
+end
+```
+
 ## Strong parameters
 
 In Rails,

--- a/README.md
+++ b/README.md
@@ -591,11 +591,11 @@ To handle user switching, you can use the following pattern in your controller:
 ```ruby
 class ApplicationController
   include Pundit::Authorization
-  before_action :switch_user, if: :should_switch_user?
 
-  def switch_user
-    current_user = User.find(params[:user_id])
-    pundit_reset!  # Ensure that the Pundit context is reset for the new user
+  def switch_user_to(user)
+    terminate_session if authenticated?
+    start_new_session_for user
+    pundit_reset!
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -660,20 +660,20 @@ class ApplicationController
 end
 ```
 
-If you need to change the context for any reason, you will need to clear the caches stored in the context. You can use the hook below to do this.
+If you need to change the context for any reason, you will need to clear the caches stored in the Pundit. You can use the hook below to do this.
 
 ```ruby
 class ApplicationController
   include Pundit::Authorization
-  before_action :switch_account, if: :should_switch_account?
+  before_action :switch_user, if: :should_switch_user?
 
   def switch_account
-    set_current_account(Account.find(params[:account_id]))
+    set_current_user(User.find(params[:user_id]))
     pundit_reset!
   end
 
   def pundit_user
-    UserContext.new(current_user, current_account)
+    UserContext.new(current_user, request.ip)
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -582,6 +582,25 @@ def pundit_user
   User.find_by_other_means
 end
 ```
+### Handling User Switching in Pundit
+
+When switching users in your application, it's important to reset the Pundit user context to ensure that authorization policies are applied correctly for the new user. Pundit caches the user context, so failing to reset it could result in incorrect permissions being applied.
+
+To handle user switching, you can use the following pattern in your controller:
+
+```ruby
+class ApplicationController
+  include Pundit::Authorization
+  before_action :switch_user, if: :should_switch_user?
+
+  def switch_user
+    current_user = User.find(params[:user_id])
+    pundit_reset!  # Ensure that the Pundit context is reset for the new user
+  end
+end
+```
+
+Make sure to invoke `pundit_reset!` whenever changing the user. This ensures the cached authorization context is reset, preventing any incorrect permissions from being applied.
 
 ## Policy Namespacing
 In some cases it might be helpful to have multiple policies that serve different contexts for a
@@ -653,24 +672,6 @@ end
 
 class ApplicationController
   include Pundit::Authorization
-
-  def pundit_user
-    UserContext.new(current_user, request.ip)
-  end
-end
-```
-
-If you need to change the context for any reason, you will need to clear the caches stored in the Pundit. You can use the hook below to do this.
-
-```ruby
-class ApplicationController
-  include Pundit::Authorization
-  before_action :switch_user, if: :should_switch_user?
-
-  def switch_account
-    set_current_user(User.find(params[:user_id]))
-    pundit_reset!
-  end
 
   def pundit_user
     UserContext.new(current_user, request.ip)

--- a/lib/pundit/authorization.rb
+++ b/lib/pundit/authorization.rb
@@ -218,6 +218,8 @@ module Pundit
 
     # @!endgroup
 
+    # @!group Customize Pundit user
+
     # Clears the cached Pundit authorization data.
     #
     # This method should be called when the pundit_user is changed,
@@ -235,5 +237,7 @@ module Pundit
       @_pundit_policy_authorized = nil
       @_pundit_policy_scoped = nil
     end
+
+    # @!endgroup
   end
 end

--- a/lib/pundit/authorization.rb
+++ b/lib/pundit/authorization.rb
@@ -217,5 +217,15 @@ module Pundit
     end
 
     # @!endgroup
+
+    # Hook method which allows to clear the Pundit context.
+    #
+    # @see https://github.com/varvet/pundit#additional-context
+    # @return [void]
+    def clear_pundit_context!
+      @pundit = nil
+      @_pundit_policies = nil
+      @_pundit_policy_scopes = nil
+    end
   end
 end

--- a/lib/pundit/authorization.rb
+++ b/lib/pundit/authorization.rb
@@ -222,7 +222,7 @@ module Pundit
     #
     # @see https://github.com/varvet/pundit#additional-context
     # @return [void]
-    def clear_pundit_context!
+    def pundit_reset!
       @pundit = nil
       @_pundit_policies = nil
       @_pundit_policy_scopes = nil

--- a/lib/pundit/authorization.rb
+++ b/lib/pundit/authorization.rb
@@ -218,9 +218,15 @@ module Pundit
 
     # @!endgroup
 
-    # Hook method which allows to clear the Pundit context.
+    # Clears the cached Pundit authorization data.
     #
-    # @see https://github.com/varvet/pundit#additional-context
+    # This method should be called when the pundit_user is changed,
+    # such as during user switching, to ensure that stale authorization
+    # data is not used. Pundit caches authorization policies and scopes
+    # for the pundit_user, so calling this method will reset those
+    # caches and ensure that the next authorization checks are performed
+    # with the correct context for the new pundit_user.
+    #
     # @return [void]
     def pundit_reset!
       @pundit = nil

--- a/lib/pundit/authorization.rb
+++ b/lib/pundit/authorization.rb
@@ -40,10 +40,31 @@ module Pundit
     # Hook method which allows customizing which user is passed to policies and
     # scopes initialized by {#authorize}, {#policy} and {#policy_scope}.
     #
+    # @note Make sure to call `pundit_reset!` if this changes during a request.
     # @see https://github.com/varvet/pundit#customize-pundit-user
+    # @see #pundit
+    # @see #pundit_reset!
     # @return [Object] the user object to be used with pundit
     def pundit_user
       current_user
+    end
+
+    # Clears the cached Pundit authorization data.
+    #
+    # This method should be called when the pundit_user is changed,
+    # such as during user switching, to ensure that stale authorization
+    # data is not used. Pundit caches authorization policies and scopes
+    # for the pundit_user, so calling this method will reset those
+    # caches and ensure that the next authorization checks are performed
+    # with the correct context for the new pundit_user.
+    #
+    # @return [void]
+    def pundit_reset!
+      @pundit = nil
+      @_pundit_policies = nil
+      @_pundit_policy_scopes = nil
+      @_pundit_policy_authorized = nil
+      @_pundit_policy_scoped = nil
     end
 
     # @!group Policies
@@ -214,28 +235,6 @@ module Pundit
     # @return [ActionController::Parameters] the params
     def pundit_params_for(record)
       params.require(PolicyFinder.new(record).param_key)
-    end
-
-    # @!endgroup
-
-    # @!group Customize Pundit user
-
-    # Clears the cached Pundit authorization data.
-    #
-    # This method should be called when the pundit_user is changed,
-    # such as during user switching, to ensure that stale authorization
-    # data is not used. Pundit caches authorization policies and scopes
-    # for the pundit_user, so calling this method will reset those
-    # caches and ensure that the next authorization checks are performed
-    # with the correct context for the new pundit_user.
-    #
-    # @return [void]
-    def pundit_reset!
-      @pundit = nil
-      @_pundit_policies = nil
-      @_pundit_policy_scopes = nil
-      @_pundit_policy_authorized = nil
-      @_pundit_policy_scoped = nil
     end
 
     # @!endgroup

--- a/lib/pundit/authorization.rb
+++ b/lib/pundit/authorization.rb
@@ -226,6 +226,8 @@ module Pundit
       @pundit = nil
       @_pundit_policies = nil
       @_pundit_policy_scopes = nil
+      @_pundit_policy_authorized = nil
+      @_pundit_policy_scoped = nil
     end
   end
 end

--- a/spec/authorization_spec.rb
+++ b/spec/authorization_spec.rb
@@ -273,7 +273,7 @@ describe Pundit::Authorization do
     end
   end
 
-  describe "#clear_pundit_context!" do
+  describe "#pundit_reset!" do
     let(:new_user) { double }
 
     it "clears the current user" do
@@ -282,7 +282,7 @@ describe Pundit::Authorization do
       controller.current_user = new_user
       expect(controller.pundit.user).not_to eq controller.current_user
 
-      controller.clear_pundit_context!
+      controller.pundit_reset!
       expect(controller.pundit.user).to eq controller.current_user
     end
 
@@ -290,7 +290,7 @@ describe Pundit::Authorization do
       controller.policy(post)
       expect(controller.policies).not_to be_empty
 
-      controller.clear_pundit_context!
+      controller.pundit_reset!
       expect(controller.policies).to be_empty
     end
 
@@ -298,7 +298,7 @@ describe Pundit::Authorization do
       controller.policy_scope(Post)
       expect(controller.policy_scopes).not_to be_empty
 
-      controller.clear_pundit_context!
+      controller.pundit_reset!
       expect(controller.policy_scopes).to be_empty
     end
   end

--- a/spec/authorization_spec.rb
+++ b/spec/authorization_spec.rb
@@ -287,19 +287,23 @@ describe Pundit::Authorization do
     end
 
     it "clears the policy cache" do
-      controller.policy(post)
+      controller.authorize(post)
       expect(controller.policies).not_to be_empty
+      expect(controller.pundit_policy_authorized?).to be true
 
       controller.pundit_reset!
       expect(controller.policies).to be_empty
+      expect(controller.pundit_policy_authorized?).to be false
     end
 
     it "clears the policy scope cache" do
       controller.policy_scope(Post)
       expect(controller.policy_scopes).not_to be_empty
+      expect(controller.pundit_policy_scoped?).to be true
 
       controller.pundit_reset!
       expect(controller.policy_scopes).to be_empty
+      expect(controller.pundit_policy_scoped?).to be false
     end
   end
 end

--- a/spec/authorization_spec.rb
+++ b/spec/authorization_spec.rb
@@ -272,4 +272,34 @@ describe Pundit::Authorization do
       expect(Controller.new(user, action, params).permitted_attributes(post, :revise).to_h).to eq("body" => "blah")
     end
   end
+
+  describe "#clear_pundit_context!" do
+    let(:new_user) { double }
+
+    it "clears the current user" do
+      expect(controller.pundit.user).to eq controller.current_user
+
+      controller.current_user = new_user
+      expect(controller.pundit.user).not_to eq controller.current_user
+
+      controller.clear_pundit_context!
+      expect(controller.pundit.user).to eq controller.current_user
+    end
+
+    it "clears the policy cache" do
+      controller.policy(post)
+      expect(controller.policies).not_to be_empty
+
+      controller.clear_pundit_context!
+      expect(controller.policies).to be_empty
+    end
+
+    it "clears the policy scope cache" do
+      controller.policy_scope(Post)
+      expect(controller.policy_scopes).not_to be_empty
+
+      controller.clear_pundit_context!
+      expect(controller.policy_scopes).to be_empty
+    end
+  end
 end

--- a/spec/support/lib/controller.rb
+++ b/spec/support/lib/controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Controller
-  attr_reader :current_user, :action_name, :params
+  attr_accessor :current_user
+  attr_reader :action_name, :params
 
   class View
     def initialize(controller)

--- a/spec/support/models/dummy_current_user.rb
+++ b/spec/support/models/dummy_current_user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DummyCurrentUser
+  def update?
+    user
+  end
+end

--- a/spec/support/policies/dummy_current_user_policy.rb
+++ b/spec/support/policies/dummy_current_user_policy.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DummyCurrentUserPolicy < BasePolicy
+  class Scope < BasePolicy::BaseScope
+    def resolve
+      user
+    end
+  end
+end


### PR DESCRIPTION
Fix https://github.com/varvet/pundit/issues/811

As far as I can see, the caches are not being cleared after a `UserContext` change. Therefore, policies are being performed using the old UserContext. I would like to implement a simple solution to this issue. With this solution, caches can be cleared when deemed necessary.

```ruby
class ApplicationController
  include Pundit::Authorization
  before_action :switch_user, if: :should_switch_user?

  def switch_user
    current_user = User.find(params[:user_id])
    pundit_reset!  # Ensure that the Pundit context is reset for the new user
  end
end
```

## To do

- [x] I have read the [contributing guidelines](https://github.com/varvet/pundit/contribute).
- [x] I have added relevant tests.
- [x] I have adjusted relevant documentation.
- [x] I have made sure the individual commits are meaningful.
- [x] I have added relevant lines to the CHANGELOG.

PS: Thank you for contributing to Pundit ❤️
