### PR TITLE
Prefer `require_relative` for internal requires

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-require "pundit/version"
-require "pundit/policy_finder"
+require_relative "pundit/version"
+require_relative "pundit/policy_finder"
+
 require "active_support/concern"
 require "active_support/core_ext/string/inflections"
 require "active_support/core_ext/object/blank"
 require "active_support/core_ext/module/introspection"
 require "active_support/dependencies/autoload"
-require "pundit/authorization"
-require "pundit/context"
-require "pundit/cache_store/null_store"
-require "pundit/cache_store/legacy_store"
+
+require_relative "pundit/authorization"
+require_relative "pundit/context"
+require_relative "pundit/cache_store/null_store"
+require_relative "pundit/cache_store/legacy_store"
 
 # @api private
 # To avoid name clashes with common Error naming when mixing in Pundit,


### PR DESCRIPTION
`require_relative` is preferred over `require` for files within the same project because it uses paths relative to the current file, making code more portable and less dependent on the load path.

This change updates internal requires to use `require_relative` for consistency, performance, and improved portability.

Refs:
- rubocop/rubocop#8748

## To do

- [x] I have read the [contributing guidelines](https://github.com/varvet/pundit/contribute).
- [x] ~I have added relevant tests.~
- [x] ~I have adjusted relevant documentation.~
- [x] I have made sure the individual commits are meaningful.
- [x] ~I have added relevant lines to the CHANGELOG.~

PS: Thank you for contributing to Pundit ❤️

---

I think this does not deserve an entry in the changelog

Relevant comment: https://github.com/rubocop/rubocop/issues/8748#issuecomment-2363327346