### PR TITLE
Move `Pundit::SUFFIX` to `Pundit::PolicyFinder::SUFFIX`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Changed
+
+- Deprecated `Pundit::SUFFIX`, moved it to `Pundit::PolicyFinder::SUFFIX` (#835)
+
 ## 2.4.0 (2024-08-26)
 
 ## Changed

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -19,7 +19,9 @@ class Pundit::Error < StandardError; end # rubocop:disable Style/ClassAndModuleC
 
 # @api public
 module Pundit
-  SUFFIX = "Policy"
+  # @api private
+  # @deprecated See {Pundit::PolicyFinder}
+  SUFFIX = Pundit::PolicyFinder::SUFFIX
 
   # @api private
   # @private

--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -10,6 +10,9 @@ module Pundit
   #   finder.scope #=> UserPolicy::Scope
   #
   class PolicyFinder
+    # @api private
+    SUFFIX = "Policy"
+
     attr_reader :object
 
     # @param object [any] the object to find policy and scope classes for

--- a/spec/policy_finder_spec.rb
+++ b/spec/policy_finder_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe Pundit::PolicyFinder do
   let(:comment) { CommentFourFiveSix.new }
   let(:article) { Article.new }
 
+  describe "SUFFIX" do
+    specify { expect(described_class::SUFFIX).to eq "Policy" }
+    specify { expect(Pundit::SUFFIX).to eq(described_class::SUFFIX) }
+  end
+
   describe "#scope" do
     subject { described_class.new(post) }
 


### PR DESCRIPTION
This sprung out of #834.

We keep the old constant as an alias for backwards-compatibility.

## To do

- [x] I have read the [contributing guidelines](https://github.com/varvet/pundit/contribute).
- [x] I have added relevant tests.
- [x] I have adjusted relevant documentation.
- [x] I have made sure the individual commits are meaningful.
- [x] I have added relevant lines to the CHANGELOG.

PS: Thank you for contributing to Pundit ❤️
