### PR TITLE
Make error message from `permit` more useful when you forget `permissions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Deprecated `Pundit::SUFFIX`, moved it to `Pundit::PolicyFinder::SUFFIX` (#835)
 - Explicitly require less of `active_support` (#837)
+- Using `permit` matcher without a surrouding `permissions` block now raises a useful error. (#836)
 
 ## 2.4.0 (2024-08-26)
 

--- a/lib/pundit/rspec.rb
+++ b/lib/pundit/rspec.rb
@@ -96,7 +96,11 @@ module Pundit
         end
 
         def permissions
-          current_example.metadata[:permissions]
+          current_example.metadata.fetch(:permissions) do
+            raise KeyError, <<~ERROR.strip
+              No permissions in example metadata, did you forget to wrap with `permissions :show?, ...`?
+            ERROR
+          end
         end
       end
       # rubocop:enable Metrics/BlockLength

--- a/spec/rspec_dsl_spec.rb
+++ b/spec/rspec_dsl_spec.rb
@@ -36,6 +36,16 @@ RSpec.describe "Pundit RSpec DSL" do
   end
 
   describe "#permit" do
+    context "when not appropriately wrapped in permissions" do
+      it "raises a descriptive error" do
+        expect do
+          expect(policy).to permit(user, post)
+        end.to raise_error(KeyError, <<~MSG.strip)
+          No permissions in example metadata, did you forget to wrap with `permissions :show?, ...`?
+        MSG
+      end
+    end
+
     permissions :edit?, :update? do
       it "succeeds when action is permitted" do
         expect(policy).to permit(user, post)


### PR DESCRIPTION
This tripped me up a bit the other day, so lets improve it.

## To do

- [x] I have read the [contributing guidelines](https://github.com/varvet/pundit/contribute).
- [x] I have added relevant tests.
- [x] I have adjusted relevant documentation.
- [x] I have made sure the individual commits are meaningful.
- [x] I have added relevant lines to the CHANGELOG.

PS: Thank you for contributing to Pundit ❤️
