### PR TITLE
Fix: `Pundit.authorize` when passing a custom cache

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,9 @@ Layout/CaseIndentation:
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Explicitly require less of `active_support` (#837)
 - Using `permit` matcher without a surrouding `permissions` block now raises a useful error. (#836)
 
+### Fixed
+
+- Using a hash as custom cache in `Pundit.authorize` now works as documented. (#838)
+
 ## 2.4.0 (2024-08-26)
 
 ## Changed

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -73,7 +73,8 @@ module Pundit
     # @see Pundit::Context#authorize
     def authorize(user, record, query, policy_class: nil, cache: nil)
       context = if cache
-        Context.new(user: user, policy_cache: cache)
+        policy_cache = CacheStore::LegacyStore.new(cache)
+        Context.new(user: user, policy_cache: policy_cache)
       else
         Context.new(user: user)
       end

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -125,6 +125,18 @@ RSpec.describe Pundit do
         expect(Pundit.authorize(user, [:project, comment], :create?, policy_class: PublicationPolicy)).to be_truthy
       end
     end
+
+    context "when passed an explicit cache" do
+      it "uses the hash assignment interface on the cache" do
+        custom_cache = CustomCache.new
+
+        Pundit.authorize(user, post, :update?, cache: custom_cache)
+
+        expect(custom_cache.to_h).to match({
+          post => kind_of(PostPolicy)
+        })
+      end
+    end
   end
 
   describe ".policy_scope" do

--- a/spec/support/lib/custom_cache.rb
+++ b/spec/support/lib/custom_cache.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CustomCache
+  def initialize
+    @store = {}
+  end
+
+  def to_h
+    @store
+  end
+
+  def [](key)
+    @store[key]
+  end
+
+  def []=(key, value)
+    @store[key] = value
+  end
+end


### PR DESCRIPTION
We accidentally broke this interface when the internal cache interface changed a while back.

## To do

- [x] I have read the [contributing guidelines](https://github.com/varvet/pundit/contribute).
- [x] I have added relevant tests.
- [x] I have adjusted relevant documentation.
- [x] I have made sure the individual commits are meaningful.
- [x] I have added relevant lines to the CHANGELOG.

PS: Thank you for contributing to Pundit ❤️
