### PR TITLE
Link to changelog in gemspec

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,7 @@ jobs:
 
   coverage-check:
     permissions:
+      contents: read
       checks: write
     needs: test
     runs-on: ubuntu-latest

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,15 @@
+inherit_from: .rubocop_ignore_git.yml
+
 AllCops:
   TargetRubyVersion: 3.1
-  Exclude:
-    - "lib/generators/**/templates/**/*"
-    <% `git status --ignored --porcelain`.lines.grep(/^!! /).each do |path| %>
-    - <%= path.sub(/^!! /, '').sub(/\/$/, '/**/*') %>
-    <% end %>
   SuggestExtensions: false
   NewCops: disable
+
+Gemspec/DeprecatedAttributeAssignment:
+  Enabled: true
+
+Gemspec/DevelopmentDependencies:
+  Enabled: true
 
 Metrics/BlockLength:
   Exclude:
@@ -25,7 +28,7 @@ Layout/LineLength:
   Max: 120
 
 Gemspec/RequiredRubyVersion:
- Enabled: false
+  Enabled: false
 
 Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
@@ -48,8 +51,8 @@ Layout/EndAlignment:
 
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
-    '%w': "[]"
-    '%W': "[]"
+    "%w": "[]"
+    "%W": "[]"
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
 Metrics/BlockLength:
   Exclude:
     - "**/*_spec.rb"
+    - pundit.gemspec
 
 Metrics/MethodLength:
   Max: 40

--- a/.rubocop_ignore_git.yml
+++ b/.rubocop_ignore_git.yml
@@ -1,0 +1,7 @@
+# This is here so we can keep YAML syntax highlight in the main file.
+AllCops:
+  Exclude:
+    - "lib/generators/**/templates/**/*"
+    <% `git status --ignored --porcelain`.lines.grep(/^!! /).each do |path| %>
+    - <%= path.sub(/^!! /, '').sub(/\/$/, '/**/*') %>
+    <% end %>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Added
 
 - Add `Pundit::Authorization#pundit_reset!` hook to reset the policy and policy scope cache. (#830)
+- Add links to gemspec. (#845)
 
 ## Changed
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,24 @@ source "https://rubygems.org"
 
 gemspec
 
+# Rails-related - for testing purposes
+gem "actionpack", ">= 3.0.0" # Used to test strong parameters
+gem "activemodel", ">= 3.0.0" # Used to test ActiveModel::Naming
+gem "railties", ">= 3.0.0" # Used to test generators
+
+# Testing
+gem "rspec", ">= 3.0.0"
+gem "simplecov", ">= 0.17.0"
+
+# Development tools
+gem "bundler"
+gem "rake"
+gem "rubocop"
+gem "rubocop-performance"
+gem "rubocop-rspec"
+gem "yard"
+gem "zeitwerk"
+
 # Affects us on JRuby 9.3.15.
 #
 # @see https://github.com/rails/rails/issues/54260

--- a/pundit.gemspec
+++ b/pundit.gemspec
@@ -19,7 +19,14 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.metadata      = { "rubygems_mfa_required" => "true" }
+  gem.metadata      = {
+    "rubygems_mfa_required" => "true",
+    "bug_tracker_uri" => "https://github.com/varvet/pundit/issues",
+    "changelog_uri" => "https://github.com/varvet/pundit/blob/main/CHANGELOG.md",
+    "documentation_uri" => "https://github.com/varvet/pundit/blob/main/README.md",
+    "homepage_uri" => "https://github.com/varvet/pundit",
+    "source_code_uri" => "https://github.com/varvet/pundit"
+  }
 
   gem.add_dependency "activesupport", ">= 3.0.0"
   gem.add_development_dependency "actionpack", ">= 3.0.0" # Used to test strong parameters.

--- a/pundit.gemspec
+++ b/pundit.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |gem|
 
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
   gem.metadata      = {
@@ -29,14 +28,4 @@ Gem::Specification.new do |gem|
   }
 
   gem.add_dependency "activesupport", ">= 3.0.0"
-  gem.add_development_dependency "actionpack", ">= 3.0.0" # Used to test strong parameters.
-  gem.add_development_dependency "activemodel", ">= 3.0.0" # Used to test ActiveModel::Naming.
-  gem.add_development_dependency "bundler"
-  gem.add_development_dependency "railties", ">= 3.0.0" # Used to test generators.
-  gem.add_development_dependency "rake"
-  gem.add_development_dependency "rspec", ">= 3.0.0"
-  gem.add_development_dependency "rubocop"
-  gem.add_development_dependency "simplecov", ">= 0.17.0"
-  gem.add_development_dependency "yard"
-  gem.add_development_dependency "zeitwerk"
 end


### PR DESCRIPTION
A well-kept changelog should be showcased! Could alternatively indent everything a little further and add a few of these; whatever your preference
```ruby
gem.metadata["key"] = "value"
```

## To do

- [x] I have read the [contributing guidelines](https://github.com/varvet/pundit/contribute).
- [x] I have added relevant tests.
- [x] I have adjusted relevant documentation.
- [x] I have made sure the individual commits are meaningful.
- [x] I have added relevant lines to the CHANGELOG.

PS: Thank you for contributing to Pundit ❤️
