### PR TITLE
Add documentation to provide a guide for how to use pundit with rails 8's built-in authentication generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `Pundit::Authorization#pundit_reset!` hook to reset the policy and policy scope cache. (#830)
 - Add links to gemspec. (#845)
 - Register policies directories for Rails 8 code statistics (#833)
+- Added an example for how to use pundit with Rails 8 authentication generator (#850)
 
 ## Changed
 

--- a/README.md
+++ b/README.md
@@ -582,6 +582,17 @@ def pundit_user
   User.find_by_other_means
 end
 ```
+
+For instance, Rails 8 comes with its built in [authentication generator](https://github.com/rails/rails/tree/8-0-stable/railties/lib/rails/generators/rails/authentication). If you opt to use that means of authentication, currently logged in user is now accessed with `Current.user` instead of `current_user`.
+
+Therefore, you should define a method named `pundit_user` like below in your `application_controller.rb` or somewhere suitable.
+
+```ruby
+def pundit_user
+  Current.user
+end
+```
+
 ### Handling User Switching in Pundit
 
 When switching users in your application, it's important to reset the Pundit user context to ensure that authorization policies are applied correctly for the new user. Pundit caches the user context, so failing to reset it could result in incorrect permissions being applied.

--- a/README.md
+++ b/README.md
@@ -583,9 +583,9 @@ def pundit_user
 end
 ```
 
-For instance, Rails 8 comes with its built in [authentication generator](https://github.com/rails/rails/tree/8-0-stable/railties/lib/rails/generators/rails/authentication). If you opt to use that means of authentication, currently logged in user is now accessed with `Current.user` instead of `current_user`.
+For instance, Rails 8 includes a built-in [authentication generator](https://github.com/rails/rails/tree/8-0-stable/railties/lib/rails/generators/rails/authentication). If you choose to use it, the currently logged-in user is accessed via `Current.user` instead of `current_user`.
 
-Therefore, you should define a method named `pundit_user` like below in your `application_controller.rb` or somewhere suitable.
+To ensure compatibility with Pundit, define a `pundit_user` method in `application_controller.rb` (or another suitable location) as follows:
 
 ```ruby
 def pundit_user


### PR DESCRIPTION
Please disregard if this is not a necessary update on the documentation.
I was testing the combination of pundit and the new rails 8 authentication generator. If you use the built in authentication generator, you would get the currently authenticated user via `Current.user` not `current_user`. Since pundit expect `current_user`, some people suggesting to add that helper to the framework. rails/rails#54202

I just thought it might be a good thing to point out that it could be resolved with the portion that is already explained in the README.

My suggestion is just to make it more obvious by giving the exact solution.

## To do

- [x] I have read the [contributing guidelines](https://github.com/varvet/pundit/contribute).
- [ ] ~~I have added relevant tests.~~
- [x] I have adjusted relevant documentation.
- [x] I have made sure the individual commits are meaningful.
- [x] I have added relevant lines to the CHANGELOG.

