### PR TITLE
Add support for params.expect

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,12 +695,12 @@ end
 In Rails,
 mass-assignment protection is handled in the controller. With Pundit you can
 control which attributes a user has access to update via your policies. You can
-set up a `permitted_attributes` method in your policy like this:
+set up an `expected_attributes` method in your policy like this:
 
 ```ruby
 # app/policies/post_policy.rb
 class PostPolicy < ApplicationPolicy
-  def permitted_attributes
+  def expected_attributes
     if user.admin? || user.owner_of?(post)
       [:title, :body, :tag_list]
     else
@@ -727,7 +727,7 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(policy(@post).permitted_attributes)
+    params.expect(policy(@post).expected_attributes)
   end
 end
 ```
@@ -739,7 +739,7 @@ However, this is a bit cumbersome, so Pundit provides a convenient helper method
 class PostsController < ApplicationController
   def update
     @post = Post.find(params[:id])
-    if @post.update(permitted_attributes(@post))
+    if @post.update(expected_attributes(@post))
       redirect_to @post
     else
       render :edit
@@ -748,22 +748,24 @@ class PostsController < ApplicationController
 end
 ```
 
-If you want to permit different attributes based on the current action, you can define a `permitted_attributes_for_#{action}` method on your policy:
+If you want to permit different attributes based on the current action, you can define an `expected_attributes_for_#{action}` method on your policy:
 
 ```ruby
 # app/policies/post_policy.rb
 class PostPolicy < ApplicationPolicy
-  def permitted_attributes_for_create
+  def expected_attributes_for_create
     [:title, :body]
   end
 
-  def permitted_attributes_for_edit
+  def expected_attributes_for_edit
     [:body]
   end
 end
 ```
 
-If you have defined an action-specific method on your policy for the current action, the `permitted_attributes` helper will call it instead of calling `permitted_attributes` on your controller.
+If you have defined an action-specific method on your policy for the current action, the `expected_attributes` helper will call it instead of calling `expected_attributes` on your controller.
+
+Pundit still support the old `params.require.permit()` style of permitting attributes, although `params.expect()` is preferred. If you want to use the old style, define methods called `permitted_attributes` and `permitted_attributes_for_*` instead.
 
 If you need to fetch parameters based on namespaces different from the suggested one, override the below method, in your controller, and return an instance of `ActionController::Parameters`.
 

--- a/lib/pundit/authorization.rb
+++ b/lib/pundit/authorization.rb
@@ -238,6 +238,29 @@ module Pundit
       pundit_params_for(record).permit(*policy.public_send(method_name))
     end
 
+    # Retrieves a set of expected attributes from the policy.
+    #
+    # Done by instantiating the policy class for the given record and calling
+    # `expected_attributes` on it, or `expected_attributes_for_{action}` if
+    # `action` is defined. It then infers what key the record should have in the
+    # params hash and retrieves the expected attributes from the params hash
+    # under that key.
+    #
+    # @see https://github.com/varvet/pundit#strong-parameters
+    # @param record [Object] the object we're retrieving expected attributes for
+    # @param action [Symbol, String] the name of the action being performed on the record (e.g. `:update`).
+    #   If omitted then this defaults to the Rails controller action name.
+    # @return [Hash{String => Object}] the expected attributes
+    def expected_attributes(record, action = action_name)
+      policy = policy(record)
+      method_name = if policy.respond_to?("expected_attributes_for_#{action}")
+        "expected_attributes_for_#{action}"
+      else
+        "expected_attributes"
+      end
+      params.expect(PolicyFinder.new(record).param_key => policy.public_send(method_name))
+    end
+
     # Retrieves the params for the given record.
     #
     # @param record [Object] the object we're retrieving params for

--- a/spec/support/policies/post_policy.rb
+++ b/spec/support/policies/post_policy.rb
@@ -33,4 +33,16 @@ class PostPolicy < BasePolicy
   def permitted_attributes_for_revise
     [:body]
   end
+
+  def expected_attributes
+    if post.user == user
+      %i[title votes]
+    else
+      [:votes]
+    end
+  end
+
+  def expected_attributes_for_revise
+    [:body]
+  end
 end


### PR DESCRIPTION
Fixes: https://github.com/varvet/pundit/issues/841

## To do

- [x] I have read the [contributing guidelines](https://github.com/varvet/pundit/contribute).
- [x] I have added relevant tests.
- [x] I have adjusted relevant documentation.
- [x] I have made sure the individual commits are meaningful.
- [ ] I have added relevant lines to the CHANGELOG.

This PR starts adding support for `params.expect` in Rails which is now recommended over `params.require.permit`.
See: https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-expect

I'm a bit unsure what to do with `pundit_params_for` though. It's kind of redundant... but also kind of useful as mentioned in our Readme, if you want to fetch based on another "namespace" than the default. However, for expect it would essentially just turn into a wrapper method for `PolicyFinder.new(record).param_key`, so you can just override the `param_key` method on the Policy instead? 🤔 