### PR TITLE
Add Ruby 4.0 to matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
           - "jruby-9.3.15"
           - "jruby"
         include: # HEAD-versions


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/
