### PR TITLE
Replace dead Carbon Five blog link with Wayback Machine archive in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,7 +851,7 @@ inherit_gem:
 # External Resources
 
 - [RailsApps Example Application: Pundit and Devise](https://github.com/RailsApps/rails-devise-pundit)
-- [Migrating to Pundit from CanCan](https://blog.carbonfive.com/2013/10/21/migrating-to-pundit-from-cancan/)
+- [Migrating to Pundit from CanCan](https://web.archive.org/web/20200415040942/https://blog.carbonfive.com/2013/10/21/migrating-to-pundit-from-cancan/)
 - [Testing Pundit Policies with RSpec](https://thunderboltlabs.com/blog/2013/03/27/testing-pundit-policies-with-rspec/)
 - [Testing Pundit with Minitest](https://github.com/varvet/pundit/issues/204#issuecomment-60166450)
 - [Using Pundit outside of a Rails controller](https://github.com/varvet/pundit/pull/136)


### PR DESCRIPTION
The link to the Carbon Five blog post "Migrating to Pundit from CanCan" in the External Resources section returns a 404.

This PR replaces it with the Wayback Machine archived version (snapshot from 2020-04-15), preserving the reference for readers who may find the migration guide useful.

### Before

```
- [Migrating to Pundit from CanCan](https://blog.carbonfive.com/...)
```

→ 404 💀

### After

```
- [Migrating to Pundit from CanCan](https://web.archive.org/web/20200415.../...)
```

→ Content accessible ✅
