### PR TITLE
Hook into scaffold generator to auto-generate policy files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Hook into scaffold generator to auto-generate policy files. [#876](https://github.com/varvet/pundit/pull/876)
+
 - Add support for `params.expect` using `expected_parameters` and `expected_parameters_for`. [#855](https://github.com/varvet/pundit/pull/855)
 
 ### Fixed

--- a/lib/pundit/railtie.rb
+++ b/lib/pundit/railtie.rb
@@ -3,6 +3,11 @@
 module Pundit
   # @since v2.5.0
   class Railtie < Rails::Railtie
+    generators do
+      require "pundit/scaffold_hook"
+      Pundit::ScaffoldHook.install
+    end
+
     if Rails.version.to_f >= 8.0
       initializer "pundit.stats_directories" do
         require "rails/code_statistics"

--- a/lib/pundit/scaffold_hook.rb
+++ b/lib/pundit/scaffold_hook.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Pundit
+  module ScaffoldHook
+    def self.install
+      return if @installed
+
+      @installed = true
+
+      require "rails/generators/rails/scaffold_controller/scaffold_controller_generator"
+
+      Rails::Generators::ScaffoldControllerGenerator.class_eval do
+        class_option :policy, type: :boolean, default: true, desc: "Generate a Pundit policy"
+
+        def generate_pundit_policy
+          return unless options[:policy]
+          invoke "pundit:policy"
+        end
+      end
+    end
+  end
+end

--- a/spec/generators_spec.rb
+++ b/spec/generators_spec.rb
@@ -40,4 +40,43 @@ RSpec.describe "generators" do
       end
     end
   end
+
+  describe "scaffold controller hook" do
+    before(:all) do
+      require "pundit/scaffold_hook"
+      Pundit::ScaffoldHook.install
+    end
+
+    it "adds --policy option to scaffold controller generator" do
+      expect(Rails::Generators::ScaffoldControllerGenerator.class_options).to have_key(:policy)
+    end
+
+    it "defaults to generating a policy" do
+      expect(Rails::Generators::ScaffoldControllerGenerator.class_options[:policy].default).to be true
+    end
+
+    it "generates policy when scaffold runs" do
+      Dir.mktmpdir do |tmpdir|
+        Dir.chdir(tmpdir) do
+          Pundit::Generators::InstallGenerator.new([], {quiet: true}).invoke_all
+
+          generator = Rails::Generators::ScaffoldControllerGenerator.new(%w[Article], {quiet: true, policy: true, orm: false, template_engine: false, helper: false, test_framework: false, resource_route: false})
+          generator.generate_pundit_policy
+
+          expect(File.exist?("app/policies/article_policy.rb")).to be true
+        end
+      end
+    end
+
+    it "skips policy generation with --no-policy" do
+      Dir.mktmpdir do |tmpdir|
+        Dir.chdir(tmpdir) do
+          generator = Rails::Generators::ScaffoldControllerGenerator.new(%w[Article], {quiet: true, policy: false, orm: false, template_engine: false, helper: false, test_framework: false, resource_route: false})
+          generator.generate_pundit_policy
+
+          expect(File.exist?("app/policies/article_policy.rb")).to be false
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #735

This hooks into the Rails scaffold controller generator to automatically generate a Pundit policy file (and its corresponding test file) when running `rails g scaffold`.

```console
$ rails g scaffold Post title:string body:text
      ...
      invoke  policy
      create    app/policies/post_policy.rb
      invoke    rspec
      create      spec/policies/post_policy_spec.rb
```

Policy generation can be skipped with `--no-policy`:

```console
$ rails g scaffold Post title:string body:text --no-policy
```

### What this does

- Adds a `--policy` option (default: `true`) to the scaffold controller generator via Railtie
- Invokes the existing `pundit:policy` generator — no new templates, no new code to maintain

### What this does NOT do

- Does not provide or maintain controller templates (per #794 feedback)
- Does not modify the generated controller code in any way

This is a surgical approach: only policy file generation, reusing the existing generator infrastructure.

**Note:** This PR addresses scaffold generation only (`rails g scaffold`). The original issue also mentions `rails g controller`, but per the discussion in #735, the initial scope is limited to scaffold. Support for `rails g controller` can be added in a follow-up if desired.

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/varvet/pundit/blob/main/CONTRIBUTING.md).
- [x] I have added relevant tests.
- [x] I have adjusted relevant documentation.
- [x] I have made sure the individual commits are meaningful.
- [x] I have added relevant lines to the CHANGELOG.