### PR TITLE
feat: add rubocop configuration for `Rails/ActionOrder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add support for `params.expect` using `expected_parameters` and `expected_parameters_for`. [#855](https://github.com/varvet/pundit/pull/855)
+- Add Rubocop configuration for `rubocop-rails`. [#879](https://github.com/varvet/pundit/pull/879)
 
 ### Fixed
 - Update for rspec 4 breaking changes [#873](https://github.com/varvet/pundit/issues/873)

--- a/README.md
+++ b/README.md
@@ -838,6 +838,8 @@ permissions :show?, :focus do
 
 Pundit does not provide a DSL for testing scopes. Test them like you would a regular Ruby class!
 
+## Rubocop
+
 ### Linting with RuboCop RSpec
 
 When you lint your RSpec spec files with `rubocop-rspec`, it will fail to properly detect RSpec constructs that Pundit defines, `permissions`.
@@ -846,6 +848,19 @@ Make sure to use `rubocop-rspec` 2.0 or newer and add the following to your `.ru
 ```yaml
 inherit_gem:
   pundit: config/rubocop-rspec.yml
+```
+
+### Linting with Rubocop Rails
+
+When you lint your policy files with `rubocop-rails`, with a little configuration you can use the
+[`Rails/ActionOrder`](https://docs.rubocop.org/rubocop-rails/latest/cops_rails.html#railsactionorder) 
+cop to enforce consistent ordering of the standard Rails RESTful controller actions.
+
+You can add the following to your `.rubocop.yml` to have this done for you:
+
+```yaml
+inherit_gem:
+  pundit: config/rubocop-rails.yml
 ```
 
 # External Resources

--- a/config/rubocop-rails.yml
+++ b/config/rubocop-rails.yml
@@ -1,0 +1,19 @@
+Rails/ActionOrder:
+  ExpectedOrder:
+    - index
+    - index?
+    - show
+    - show?
+    - new
+    - new?
+    - edit
+    - edit?
+    - create
+    - create?
+    - update
+    - update?
+    - destroy
+    - destroy?
+  Include:
+    - '**/app/controllers/**'
+    - '**/app/policies/**'


### PR DESCRIPTION
I realized this is a thing we can do, which I think is pretty cool 😄

## To do

- [x] I have read the [contributing guidelines](https://github.com/varvet/pundit/contribute).
- [x] ~I have added relevant tests.~
- [x] I have adjusted relevant documentation.
- [x] I have made sure the individual commits are meaningful.
- [x] I have added relevant lines to the CHANGELOG.

PS: Thank you for contributing to Pundit ❤️
