### PR TITLE
fix #878: avoid policies action collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - Update for rspec 4 breaking changes [#873](https://github.com/varvet/pundit/issues/873)
+- Allow controllers to define a `policies` action without interfering with Pundit's policy cache. [#878](https://github.com/varvet/pundit/issues/878)
 
 ## 2.5.2 (2025-09-24)
 

--- a/lib/pundit/authorization.rb
+++ b/lib/pundit/authorization.rb
@@ -35,7 +35,7 @@ module Pundit
     def pundit
       @pundit ||= Pundit::Context.new(
         user: pundit_user,
-        policy_cache: Pundit::CacheStore::LegacyStore.new(policies)
+        policy_cache: Pundit::CacheStore::LegacyStore.new(pundit_policies)
       )
     end
 
@@ -132,9 +132,14 @@ module Pundit
     # Cache of policies. You should not rely on this method.
     #
     # @api private
+    def pundit_policies
+      @_pundit_policies ||= {}
+    end
+
+    # @api private
     # @since v1.0.0
     def policies
-      @_pundit_policies ||= {}
+      pundit_policies
     end
 
     # rubocop:enable Naming/MemoizedInstanceVariableName

--- a/spec/authorization_spec.rb
+++ b/spec/authorization_spec.rb
@@ -113,6 +113,20 @@ RSpec.describe Pundit::Authorization do
       expect(controller.policies[post]).not_to be_nil
     end
 
+    context "when the controller has an action named policies" do
+      let(:controller) do
+        Class.new(Controller) do
+          def policies
+            :policies_action
+          end
+        end.new(user, "update", to_params({}))
+      end
+
+      it "does not use the action as its policy cache" do
+        expect(controller.authorize(post)).to be_truthy
+      end
+    end
+
     it "raises an error when the given record is nil" do
       expect { controller.authorize(nil, :destroy?) }.to raise_error(Pundit::NotAuthorizedError)
     end


### PR DESCRIPTION
## motivation / background

Pundit::Authorization#pundit used policies as its cache hook. a controller action with the same name overrides that method, so its return value is passed to the policy cache and authorization fails.

fixes #878

## detail

this uses pundit_policies internally for the cache and keeps policies as a compatibility delegate. it also adds a regression spec for a controller with a policies action.

## checks

- [x] i have read the contributing guidelines
- [x] this pull request is related to one change
- [x] i have added relevant tests
- [x] i have adjusted relevant documentation
- [x] i have made sure the individual commit is meaningful
- [x] i have added a relevant changelog entry
- [x] bundle exec rspec: 162 examples, 0 failures
- [x] bundle exec standardrb